### PR TITLE
Checksum validation on score submission, login cleanup & storing of client details

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -509,9 +509,9 @@ async def login(
         }
 
     running_under_wine = login_data["adapters_str"] == "runningunderwine"
-    adapters = [a for a in login_data["adapters_str"][:-1].split(".") if a]
+    adapters = [a for a in login_data["adapters_str"][:-1].split(".")]
 
-    if not (running_under_wine or adapters):
+    if not (running_under_wine or any(adapters)):
         return {
             "osu_token": "empty-adapters",
             "response_body": (

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -616,7 +616,7 @@ async def osuSubmitModularSelector(
         return
 
     # parse the score from the remaining data
-    score = await Score.from_submission(score_data[2:])
+    score = Score.from_submission(score_data[2:])
 
     # attach bmap & player
     score.bmap = bmap

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -555,6 +555,11 @@ def chart_entry(name: str, before: Optional[T], after: T) -> str:
 @router.post("/web/osu-submit-modular-selector.php")
 async def osuSubmitModularSelector(
     request: Request,
+    # TODO: should token be allowed
+    # through but ac'd if not found?
+    # TODO: validate token format
+    # TODO: save token in the database
+    token: str = Header(...),
     # TODO: do ft & st contain pauses?
     exited_out: bool = Form(..., alias="x"),
     fail_time: int = Form(..., alias="ft"),

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -625,8 +625,8 @@ async def osuSubmitModularSelector(
     client_hash_decoded = aes.decrypt(b64decode(client_hash_b64)).decode()
 
     try:
-        # TODO: assert osu_version
-        # TODO: assert client_hash
+        assert osu_version == f"{player.client_details.osu_version.date:%Y%m%d}"
+        assert client_hash_decoded == player.client_details.client_hash
         assert player.client_details is not None
 
         # assert unique ids (c1) are correct and match login params

--- a/app/commands.py
+++ b/app/commands.py
@@ -905,7 +905,7 @@ async def user(ctx: Context) -> Optional[str]:
             f"Channels: {[p._name for p in p.channels]}",
             f"Logged in: {timeago.format(p.login_time)}",
             f"Last server interaction: {timeago.format(p.last_recv_time)}",
-            f"osu! build: {p.osu_ver} | Tourney: {p.tourney_client}",
+            f"osu! build: {p.client_details.osu_version} | Tourney: {p.tourney_client}",
             f"Silenced: {p.silenced} | Spectating: {p.spectating}",
             f"Last /np: {last_np}",
             f"Recent score: {p.recent_score}",

--- a/app/commands.py
+++ b/app/commands.py
@@ -905,7 +905,7 @@ async def user(ctx: Context) -> Optional[str]:
             f"Channels: {[p._name for p in p.channels]}",
             f"Logged in: {timeago.format(p.login_time)}",
             f"Last server interaction: {timeago.format(p.last_recv_time)}",
-            f"osu! build: {p.client_details.osu_version} | Tourney: {p.tourney_client}",
+            f"osu! build: {p.client_details.osu_version.date} | Tourney: {p.tourney_client}",
             f"Silenced: {p.silenced} | Spectating: {p.spectating}",
             f"Last /np: {last_np}",
             f"Recent score: {p.recent_score}",
@@ -1549,9 +1549,6 @@ if app.settings.DEVELOPER_MODE:
 
         if "__py" in __py_namespace:
             del __py_namespace["__py"]
-
-        if ret is None:
-            return "Success"
 
         # TODO: perhaps size checks?
 

--- a/app/constants/regexes.py
+++ b/app/constants/regexes.py
@@ -6,7 +6,7 @@ __all__ = ("OSU_VERSION", "USERNAME", "EMAIL", "BEST_OF")
 
 
 OSU_VERSION = re.compile(
-    r"^b(?P<ver>\d{8})(?:\.(?P<subver>\d))?"
+    r"^b(?P<date>\d{8})(?:\.(?P<revision>\d))?"
     r"(?P<stream>beta|cuttingedge|dev|tourney)?$",
 )
 

--- a/app/objects/match.py
+++ b/app/objects/match.py
@@ -495,7 +495,7 @@ class Match:
                 if (
                     rc_score
                     and rc_score.bmap.md5 == self.map_md5
-                    and rc_score.play_time > max_age
+                    and rc_score.server_time > max_age
                 ):
                     # score found, add to our scores dict if != 0.
                     if score := getattr(rc_score, win_cond):

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -432,7 +432,7 @@ class Player:
                 score = s
                 continue
 
-            if s.play_time > score.play_time:
+            if s.server_time > score.server_time:
                 score = s
 
         return score

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -180,6 +180,14 @@ class ClientDetails:
         self.adapters = adapters
         self.ip = ip
 
+    @cached_property
+    def client_hash(self) -> str:
+        return (
+            # NOTE the extra '.' and ':' appended to ends
+            f"{self.osu_path_md5}:{'.'.join(self.adapters)}."
+            f":{self.adapters_md5}:{self.uninstall_md5}:{self.disk_signature_md5}:"
+        )
+
     # TODO: __str__ to pack like osu! hashes?
 
 

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -8,6 +8,7 @@ from enum import IntEnum
 from enum import unique
 from functools import cached_property
 from typing import Any
+from typing import Literal
 from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypedDict
@@ -143,10 +144,26 @@ class LastNp(TypedDict):
     timeout: float
 
 
+class OsuVersion:
+    # b20200201.2cuttingedge
+    # date = 2020/02/01
+    # revision = 2
+    # stream = cuttingedge
+    def __init__(
+        self,
+        date: date,
+        revision: Optional[int],  # TODO: should this be optional?
+        stream: Literal["stable", "beta", "cuttingedge", "tourney", "dev"],
+    ) -> None:
+        self.date = date
+        self.revision = revision
+        self.stream = stream
+
+
 class ClientDetails:
     def __init__(
         self,
-        osu_version: date,
+        osu_version: OsuVersion,
         osu_path_md5: str,
         adapters_md5: str,
         uninstall_md5: str,

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -21,6 +21,7 @@ from cmyui.logging import log
 import app.packets
 import app.settings
 import app.state
+from app._typing import IPAddress
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
 from app.constants.privileges import ClientPrivileges
@@ -142,6 +143,29 @@ class LastNp(TypedDict):
     timeout: float
 
 
+class ClientDetails:
+    def __init__(
+        self,
+        osu_version: date,
+        osu_path_md5: str,
+        adapters_md5: str,
+        uninstall_md5: str,
+        disk_signature_md5: str,
+        adapters: list[str],
+        ip: IPAddress,
+    ) -> None:
+        self.osu_version = osu_version
+        self.osu_path_md5 = osu_path_md5
+        self.adapters_md5 = adapters_md5
+        self.uninstall_md5 = uninstall_md5
+        self.disk_signature_md5 = disk_signature_md5
+
+        self.adapters = adapters
+        self.ip = ip
+
+    # TODO: __str__ to pack like osu! hashes?
+
+
 class Player:
     """\
     Server side representation of a player; not necessarily online.
@@ -205,7 +229,7 @@ class Player:
         "away_msg",
         "silence_end",
         "in_lobby",
-        "osu_ver",
+        "client_details",
         "pres_filter",
         "login_time",
         "last_recv_time",
@@ -257,8 +281,8 @@ class Player:
         self.match: Optional[Match] = None
         self.stealth = False
 
-        self.clan: Optional[Clan] = extras.get("clan", None)
-        self.clan_priv: Optional[ClanPrivileges] = extras.get("clan_priv", None)
+        self.clan: Optional[Clan] = extras.get("clan")
+        self.clan_priv: Optional[ClanPrivileges] = extras.get("clan_priv")
 
         self.achievements: set[Achievement] = set()
 
@@ -276,7 +300,8 @@ class Player:
         self.away_msg: Optional[str] = None
         self.silence_end = extras.get("silence_end", 0)
         self.in_lobby = False
-        self.osu_ver: Optional[date] = extras.get("osu_ver", None)
+
+        self.client_details: Optional[ClientDetails] = extras.get("client_details")
         self.pres_filter = PresenceFilter.Nil
 
         login_time = extras.get("login_time", 0.0)

--- a/app/objects/score.py
+++ b/app/objects/score.py
@@ -266,7 +266,7 @@ class Score:
         return s
 
     @classmethod
-    async def from_submission(cls, data: list[str]) -> Score:
+    def from_submission(cls, data: list[str]) -> Score:
         """Create a score object from an osu! submission string."""
         s = cls()
 

--- a/app/objects/score.py
+++ b/app/objects/score.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import hashlib
 import math
 from datetime import datetime
 from enum import IntEnum
@@ -143,10 +144,11 @@ class Score:
         "passed",
         "perfect",
         "status",
-        "play_time",
+        "client_time",
+        "server_time",
         "time_elapsed",
         "client_flags",
-        "online_checksum",
+        "client_checksum",
         "prev_best",
     )
 
@@ -180,20 +182,25 @@ class Score:
         self.perfect: bool
         self.status: SubmissionStatus
 
-        self.play_time: datetime
+        self.client_time: datetime
+        self.server_time: datetime
         self.time_elapsed: int
 
         self.client_flags: ClientFlags
-        self.online_checksum: str
+        self.client_checksum: str
 
         self.rank: Optional[int] = None
         self.prev_best: Optional[Score] = None
 
-    def __repr__(self) -> str:  # maybe shouldn't be so long?
-        return (
-            f"<{self.acc:.2f}% {self.max_combo}x {self.nmiss}M "
-            f"#{self.rank} on {self.bmap.full_name} for {self.pp:,.2f}pp>"
-        )
+    def __repr__(self) -> str:
+        # TODO: i really need to clean up my reprs
+        try:
+            return (
+                f"<{self.acc:.2f}% {self.max_combo}x {self.nmiss}M "
+                f"#{self.rank} on {self.bmap.full_name} for {self.pp:,.2f}pp>"
+            )
+        except:
+            return super().__repr__()
 
     """Classmethods to fetch a score object from various data types."""
 
@@ -239,10 +246,10 @@ class Score:
             s.perfect,
             s.status,
             s.mode,
-            s.play_time,
+            s.server_time,
             s.time_elapsed,
             s.client_flags,
-            s.online_checksum,
+            s.client_checksum,
         ) = row[3:]
 
         # fix some types
@@ -282,29 +289,57 @@ class Score:
         # 15 osu_version + (" " * client_flags)
         """
 
-        s.online_checksum = data[0]
-
-        s.n300, s.n100, s.n50, s.ngeki, s.nkatu, s.nmiss, s.score, s.max_combo = map(
-            int,
-            data[1:9],
-        )
-
+        s.client_checksum = data[0]
+        s.n300 = int(data[1])
+        s.n100 = int(data[2])
+        s.n50 = int(data[3])
+        s.ngeki = int(data[4])
+        s.nkatu = int(data[5])
+        s.nmiss = int(data[6])
+        s.score = int(data[7])
+        s.max_combo = int(data[8])
         s.perfect = data[9] == "True"
-        _grade = data[10]  # letter grade
+        s.grade = Grade.from_str(data[10])
         s.mods = Mods(int(data[11]))
         s.passed = data[12] == "True"
         s.mode = GameMode.from_params(int(data[13]), s.mods)
-
-        # TODO: we might want to use data[14] to get more
-        #       accurate submission time (client side) but
-        #       we'd probably want to check if it's close.
-        s.play_time = datetime.now()
-
+        s.client_time = datetime.strptime(data[14], "%y%m%d%H%M%S")
         s.client_flags = ClientFlags(data[15].count(" ") & ~4)
 
-        s.grade = Grade.from_str(_grade) if s.passed else Grade.F
+        s.server_time = datetime.now()
 
         return s
+
+    def compute_online_checksum(
+        self,
+        osu_version: str,
+        osu_client_hash: str,
+        storyboard_checksum: str,
+    ) -> str:
+        """Validate the online checksum of the score."""
+        return hashlib.md5(
+            "chickenmcnuggets{0}o15{1}{2}smustard{3}{4}uu{5}{6}{7}{8}{9}{10}{11}Q{12}{13}{15}{14:%y%m%d%H%M%S}{16}{17}".format(
+                self.n100 + self.n300,
+                self.n50,
+                self.ngeki,
+                self.nkatu,
+                self.nmiss,
+                self.bmap.md5,
+                self.max_combo,
+                self.perfect,
+                self.player.name,
+                self.score,
+                self.grade.name,
+                int(self.mods),
+                self.passed,
+                self.mode.as_vanilla,
+                self.client_time,
+                osu_version,  # 20210520
+                osu_client_hash,
+                storyboard_checksum,
+                # yyMMddHHmmss
+            ).encode(),
+        ).hexdigest()
 
     """Methods to calculate internal data for a score."""
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -58,6 +58,8 @@ __all__ = (
     "create_config_from_default",
     "orjson_serialize_to_str",
     "get_media_type",
+    "has_jpeg_headers_and_trailers",
+    "has_png_headers_and_trailers",
 )
 
 DATA_PATH = Path.cwd() / ".data"
@@ -558,3 +560,14 @@ def get_media_type(extension: str) -> Optional[str]:
         return "image/png"
 
     # return none, fastapi will attempt to figure it out
+
+
+def has_jpeg_headers_and_trailers(data_view: memoryview) -> bool:
+    return data_view[:4] == b"\xff\xd8\xff\xe0" and data_view[6:11] == b"JFIF\x00"
+
+
+def has_png_headers_and_trailers(data_view: memoryview) -> bool:
+    return (
+        data_view[:8] == b"\x89PNG\r\n\x1a\n"
+        and data_view[-8] == b"\x49END\xae\x42\x60\x82"
+    )


### PR DESCRIPTION
- add score submission 'anticheat' (server-side validation of score checksum, unique ids, client hashes, osu version)
- stored client details (client hashes, adapters, ip, osu version) in Player object
- decouple login & score submission data parsing from controllers
- misc code clean up on login & score submission controllers
- overall code cleanup & improvements

'anticheat' does not yet perform automatic restrictions when these assertions are not met - but instead logs to my server.
the functionality is in place to perform restrictions, and will be enabled after a trial period to ensure all is well & tested.

thanks to @xxCherry & @infernalfire72 for the tips for improvements :)