### PR TITLE
Fixed check whether the user exists in changename

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -280,14 +280,15 @@ async def changename(ctx: Context) -> Optional[str]:
     if name in app.settings.DISALLOWED_NAMES:
         return "Disallowed username; pick another."
 
+    safe_name = name.lower().replace(" ", "_")
+
     if await app.state.services.database.fetch_one(
-        "SELECT 1 FROM users WHERE name = :name",
-        {"name": name},
+        "SELECT 1 FROM users WHERE safe_name = :safe_name",
+        {"safe_name": safe_name},
     ):
         return "Username already taken by another player."
 
     # all checks passed, update their name
-    safe_name = name.lower().replace(" ", "_")
 
     await app.state.services.database.execute(
         "UPDATE users SET name = :name, safe_name = :safe_name WHERE id = :user_id",

--- a/app/commands.py
+++ b/app/commands.py
@@ -289,7 +289,6 @@ async def changename(ctx: Context) -> Optional[str]:
         return "Username already taken by another player."
 
     # all checks passed, update their name
-
     await app.state.services.database.execute(
         "UPDATE users SET name = :name, safe_name = :safe_name WHERE id = :user_id",
         {"name": name, "safe_name": safe_name, "user_id": ctx.player.id},


### PR DESCRIPTION
It used the name column instead of safe_name, resulting in an SQL error that the safe_name column is unique.

Example: User "test 123" exists and you want to change your name to "test_123"