### PR TITLE
Fix OpenAPI docs not being generated

### DIFF
--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -40,6 +40,9 @@ class BanchoAPI(FastAPI):
                 if isinstance(host, starlette.routing.Host)
             ]
 
+            # XXX:HACK fastapi will not show documentation for routes
+            # added through use sub applications using the Host class
+            # (e.g. app.host('other.domain', app2))
             for host in starlette_hosts:
                 for route in host.routes:
                     if route not in routes:

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -32,31 +32,33 @@ from app.objects import collections
 
 class BanchoAPI(FastAPI):
     def openapi(self) -> dict[str, Any]:
-        if self.openapi_schema:
-            return self.openapi_schema
+        if not self.openapi_schema:
+            routes = self.routes
+            starlette_hosts = [
+                host
+                for host in super().routes
+                if isinstance(host, starlette.routing.Host)
+            ]
 
-        routes = self.routes
-        starlette_hosts = [
-            host for host in super().routes if isinstance(host, starlette.routing.Host)
-        ]
+            for host in starlette_hosts:
+                for route in host.routes:
+                    if route not in routes:
+                        routes.append(route)
 
-        for host in starlette_hosts:
-            for route in host.routes:
-                if route not in routes:
-                    routes.append(route)
+            self.openapi_schema = get_openapi(
+                title=self.title,
+                version=self.version,
+                openapi_version=self.openapi_version,
+                description=self.description,
+                terms_of_service=self.terms_of_service,
+                contact=self.contact,
+                license_info=self.license_info,
+                routes=routes,
+                tags=self.openapi_tags,
+                servers=self.servers,
+            )
 
-        self.openapi_schema = get_openapi(
-            title=self.title,
-            version=self.version,
-            openapi_version=self.openapi_version,
-            description=self.description,
-            terms_of_service=self.terms_of_service,
-            contact=self.contact,
-            license_info=self.license_info,
-            routes=routes,
-            tags=self.openapi_tags,
-            servers=self.servers,
-        )
+        return self.openapi_schema
 
 
 def init_exception_handlers(asgi_app: BanchoAPI) -> None:

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -32,8 +32,10 @@ from app.objects import collections
 
 class BanchoAPI(FastAPI):
     def openapi(self) -> dict[str, Any]:
-        routes = self.routes
+        if self.openapi_schema:
+            return self.openapi_schema
 
+        routes = self.routes
         starlette_hosts = [
             host for host in super().routes if isinstance(host, starlette.routing.Host)
         ]
@@ -43,20 +45,18 @@ class BanchoAPI(FastAPI):
                 if route not in routes:
                     routes.append(route)
 
-        if not self.openapi_schema:
-            self.openapi_schema = get_openapi(
-                title=self.title,
-                version=self.version,
-                openapi_version=self.openapi_version,
-                description=self.description,
-                terms_of_service=self.terms_of_service,
-                contact=self.contact,
-                license_info=self.license_info,
-                routes=routes,
-                tags=self.openapi_tags,
-                servers=self.servers,
-            )
-        return self.openapi_schema
+        self.openapi_schema = get_openapi(
+            title=self.title,
+            version=self.version,
+            openapi_version=self.openapi_version,
+            description=self.description,
+            terms_of_service=self.terms_of_service,
+            contact=self.contact,
+            license_info=self.license_info,
+            routes=routes,
+            tags=self.openapi_tags,
+            servers=self.servers,
+        )
 
 
 def init_exception_handlers(asgi_app: BanchoAPI) -> None:

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -8,17 +8,17 @@ from typing import Any
 
 import aiohttp
 import orjson
+import starlette.routing
 from fastapi import FastAPI
 from fastapi import status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
+from fastapi.openapi.utils import get_openapi
 from fastapi.requests import Request
 from fastapi.responses import ORJSONResponse
 from fastapi.responses import Response
 from starlette.middleware.base import RequestResponseEndpoint
-from fastapi.openapi.utils import get_openapi
 
-import starlette.routing
 import app.bg_loops
 import app.settings
 import app.state


### PR DESCRIPTION
This was an internal issue where `.host()` would only interface Starlette, creating a `Host` object which FastAPI cannot deal with.

The fix this PR provides is a subclass of FastAPI which modifies the `.openapi()` call to include the routes from the `Host` objects it contains.