### PR TITLE
Make users unable to assign donator privileges using !addpriv

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -1385,7 +1385,7 @@ async def addpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
-    
+
     if bits & Privileges.DONATOR:
         return "Please use the !givedonator command to assign donator privileges to players."
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -1406,7 +1406,7 @@ async def rmpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
-    
+
     if bits & Privileges.DONATOR:
         return "Please use the !givedonator command to assign donator privileges to players."
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -1406,6 +1406,9 @@ async def rmpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
+    
+    if bits & Privileges.DONATOR:
+        return "Please use the !givedonator command to assign donator privileges to players."
 
     await t.remove_privs(bits)
     return f"Updated {t}'s privileges."

--- a/app/commands.py
+++ b/app/commands.py
@@ -1385,6 +1385,9 @@ async def addpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
+    
+    if bits & Privileges.DONATOR:
+        return "Please use the !givedonator command to assign donator privileges to players."
 
     await t.add_privs(bits)
     return f"Updated {t}'s privileges."
@@ -1406,9 +1409,6 @@ async def rmpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
-
-    if bits & Privileges.DONATOR:
-        return "Please use the !givedonator command to assign donator privileges to players."
 
     await t.remove_privs(bits)
     return f"Updated {t}'s privileges."


### PR DESCRIPTION
addpriv does not set a donator end therefore the background task will remove the donator privileges after some time anyway.
To hint users the proper way to assign donator privileges just make them unable to assign the privileges and return an error instead.