### PR TITLE
made rmpriv set donor_end back to 0

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -1406,6 +1406,12 @@ async def rmpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
+    
+    if bits & Privileges.DONATOR:
+        await app.state.services.database.execute(
+            "UPDATE users SET donor_end = 0 WHERE id = :user_id",
+            {"user_id": t.id},
+        )
 
     await t.remove_privs(bits)
     return f"Updated {t}'s privileges."

--- a/app/commands.py
+++ b/app/commands.py
@@ -1408,13 +1408,13 @@ async def rmpriv(ctx: Context) -> Optional[str]:
         return "Could not find user."
 
     await t.remove_privs(bits)
-   
+
     if bits & Privileges.DONATOR:
         await app.state.services.database.execute(
             "UPDATE users SET donor_end = 0 WHERE id = :user_id",
             {"user_id": t.id},
         )
-        
+
     return f"Updated {t}'s privileges."
 
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -1406,7 +1406,7 @@ async def rmpriv(ctx: Context) -> Optional[str]:
 
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
-    
+
     if bits & Privileges.DONATOR:
         await app.state.services.database.execute(
             "UPDATE users SET donor_end = 0 WHERE id = :user_id",

--- a/app/commands.py
+++ b/app/commands.py
@@ -1407,13 +1407,14 @@ async def rmpriv(ctx: Context) -> Optional[str]:
     if not (t := await app.state.sessions.players.from_cache_or_sql(name=ctx.args[0])):
         return "Could not find user."
 
+    await t.remove_privs(bits)
+   
     if bits & Privileges.DONATOR:
         await app.state.services.database.execute(
             "UPDATE users SET donor_end = 0 WHERE id = :user_id",
             {"user_id": t.id},
         )
-
-    await t.remove_privs(bits)
+        
     return f"Updated {t}'s privileges."
 
 


### PR DESCRIPTION
This is important as when you manually remove the donator privileges instead of the background task it results in the donor_end not being changed at all. If you use the givedonator command on that player again, the specified time will add up with the existing donor_end.

Example:
user1 gets donator for 10 minutes
donator privileges are removed from user1
user1 gets donator 10 minutes
Result: because the removal did not reset donor_end, the 10 minutes are added to donor_end instead of time.time()