### PR TITLE
fix: bonus pp formula

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -1002,7 +1002,7 @@ async def osuSubmitModularSelector(
 
             # calculate new total weighted pp
             weighted_pp = sum(row["pp"] * 0.95**i for i, row in enumerate(top_100_pp))
-            bonus_pp = 416.6667 * (1 - 0.95**total_scores)
+            bonus_pp = 416.6667 * (1 - 0.9994**total_scores)
             stats.pp = round(weighted_pp + bonus_pp)
 
             # add pp to query


### PR DESCRIPTION
According to the [docs](https://osu.ppy.sh/wiki/en/Performance_points), the bonus pp formula is
```
416.6667 * (1 - 0.9994 ^ N)
```

Which does not match up here
https://github.com/osuAkatsuki/bancho.py/blob/1bc4424406bd74dbb576fc7027b4460405e19e35/app/api/domains/osu.py#L1005

Changing 0.95 to 0.9994 seems like a pointless change, but it actually has a huge affect on how bonus pp works. To achieve the maximum amount of bonus pp on bancho, you would need to set 25397 scores on ranked maps which is quite a lot. But because 0.9994 was shortened to 0.95, you would only need to set 200 scores to hit the limit.