### PR TITLE
Add db column to track when a user added map as a favourite; add redirect for beatmapset discussion page

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -1665,6 +1665,7 @@ if app.settings.REDIRECT_OSU_URLS:
     for pattern in (
         "/beatmapsets/{_}",
         "/beatmaps/{_}",
+        "/beatmapsets/{_}/discussion",
         "/community/forums/topics/{_}",
     ):
         router.get(pattern)(osu_redirect)

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -327,7 +327,7 @@ async def osuAddFavourite(
 
     # add favourite
     await app.state.services.database.execute(
-        "INSERT INTO favourites VALUES (:user_id, :set_id)",
+        "INSERT INTO favourites VALUES (:user_id, :set_id, UNIX_TIMESTAMP())",
         {"user_id": player.id, "set_id": map_set_id},
     )
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -55,4 +55,4 @@ DEVELOPER_MODE = config("DEVELOPER_MODE", cast=bool)
 ## WARNING touch this if you know how
 ##          the migrations system works.
 ##          you'll regret it.
-VERSION = "4.4.2"
+VERSION = "4.4.3"

--- a/migrations/base.sql
+++ b/migrations/base.sql
@@ -71,6 +71,7 @@ create table favourites
 (
 	userid int not null,
 	setid int not null,
+	fav_time int default 0 not null,
 	primary key (userid, setid)
 );
 

--- a/migrations/base.sql
+++ b/migrations/base.sql
@@ -71,7 +71,7 @@ create table favourites
 (
 	userid int not null,
 	setid int not null,
-	fav_time int default 0 not null,
+	created_at int default 0 not null,
 	primary key (userid, setid)
 );
 

--- a/migrations/migrations.sql
+++ b/migrations/migrations.sql
@@ -399,3 +399,6 @@ insert into achievements (id, file, name, `desc`, cond) values (80, 'all-intro-n
 insert into achievements (id, file, name, `desc`, cond) values (81, 'all-intro-nightcore', 'Sweet Rave Party', 'Founded in the fine tradition of changing things that were just fine as they were.', 'score.mods & 512');
 insert into achievements (id, file, name, `desc`, cond) values (82, 'all-intro-halftime', 'Slowboat', 'You got there. Eventually.', 'score.mods & 256');
 insert into achievements (id, file, name, `desc`, cond) values (83, 'all-intro-spunout', 'Burned Out', 'One cannot always spin to win.', 'score.mods & 4096');
+
+# v4.4.3
+alter table favourites add created_at int default 0 not null;


### PR DESCRIPTION
Favourite beatmaps on bancho will show in the order that you favourite them:
![image](https://user-images.githubusercontent.com/106853042/180334549-756258c9-b86d-4b41-9a15-5ee505421bde.png)

I'd like to do the same on bancho.py, but it isn't possible as the only two colums are `userid` and `setid`. Instead, the order is based on when the beatmap itself was inserted into the `maps` database. My only other option is to order by the beatmap's `last_update`. Adding `fav_time` allows me to sort by the time the map was favourited, and gives more flexibility for future queries. I think it would be a pretty useful addition for both me, and any other frontend/api projects.

I also added a redirect for beatmap threads. I'm aware the code will likely be [removed](https://github.com/osuAkatsuki/bancho.py/blob/592d386f70aee2c1c0833250642ea0b5ea97cd52/app/api/domains/osu.py#L1658) but I can't see a frontend making use of this anytime soon.

```sql
ALTER TABLE favourites ADD fav_time INT DEFAULT 0 NOT NULL;
```