### PR TITLE
Call `.value` on release stream upon fetching build info from osu!

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -499,7 +499,7 @@ async def login(
 
         async with services.http_client.get(
             OSU_API_V2_CHANGELOG_URL,
-            params={"stream": osu_client_stream},
+            params={"stream": osu_client_stream.value},
         ) as resp:
             for build in (await resp.json())["builds"]:
                 version = date(


### PR DESCRIPTION
In the current state, osu! will not return anything in builds dict since server tries to get builds with stream `OsuStream.CUTTINGEDGE` for example instead of it's normal name.