### PR TITLE
Maps forced update & More leaderboards & Status check

### DIFF
--- a/app/api/domains/api.py
+++ b/app/api/domains/api.py
@@ -9,14 +9,14 @@ from typing import Optional
 
 import databases.core
 from fastapi import APIRouter
+from fastapi import Header
 from fastapi import HTTPException
 from fastapi import status
-from fastapi import Header
 from fastapi.param_functions import Depends
-from fastapi.security.oauth2 import SecurityScopes
 from fastapi.param_functions import Query
 from fastapi.responses import ORJSONResponse
 from fastapi.responses import StreamingResponse
+from fastapi.security.oauth2 import SecurityScopes
 
 import app.packets
 import app.state
@@ -67,19 +67,25 @@ router = APIRouter(tags=["bancho.py API"])
 
 DATETIME_OFFSET = 0x89F7FF5F7B58000
 
+
 async def get_player(
-    security_scopes: SecurityScopes, api_key: str = Header(alias='Authorization', default=None)
+    security_scopes: SecurityScopes,
+    api_key: str = Header(alias="Authorization", default=None),
 ):
     if api_key is None:
-        raise HTTPException(status_code=400, detail={"status": "Must provide authorization token."})
+        raise HTTPException(
+            status_code=400, detail={"status": "Must provide authorization token."},
+        )
     if api_key not in app.state.sessions.api_keys:
-        raise HTTPException(status_code=401, detail={"status": "Unknown authorization token."})
+        raise HTTPException(
+            status_code=401, detail={"status": "Unknown authorization token."},
+        )
     player_id = app.state.sessions.api_keys[api_key]
     player = await app.state.sessions.players.from_cache_or_sql(id=player_id)
     for scope in security_scopes.scopes:
         priv = Privileges[scope.upper()]
         if not player.priv & priv:
-            raise HTTPException(status_code=403, detail={"status": "No Permission."}) 
+            raise HTTPException(status_code=403, detail={"status": "No Permission."})
     return player
 
 

--- a/app/api/domains/api.py
+++ b/app/api/domains/api.py
@@ -8,7 +8,8 @@ from typing import Literal
 from typing import Optional
 
 import databases.core
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
+from fastapi import HTTPException
 from fastapi import status
 from fastapi.param_functions import Depends
 from fastapi.param_functions import Query
@@ -21,7 +22,8 @@ from app.constants import regexes
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
 from app.constants.privileges import Privileges
-from app.objects.beatmap import Beatmap, BeatmapSet
+from app.objects.beatmap import Beatmap
+from app.objects.beatmap import BeatmapSet
 from app.objects.clan import Clan
 from app.objects.player import Player
 from app.state.services import acquire_db_conn
@@ -64,7 +66,10 @@ router = APIRouter(tags=["bancho.py API"])
 
 DATETIME_OFFSET = 0x89F7FF5F7B58000
 
-async def check_player(api_key: str, priv: Privileges = Privileges.UNRESTRICTED) -> Player:
+
+async def check_player(
+    api_key: str, priv: Privileges = Privileges.UNRESTRICTED,
+) -> Player:
     if api_key not in app.state.sessions.api_keys:
         raise HTTPException(status_code=401, detail={"status": "Invaild API Key."})
     player_id = app.state.sessions.api_keys[api_key]
@@ -947,19 +952,16 @@ async def api_get_pool(
         },
     )
 
+
 @router.get("/update_maps")
 async def api_update_maps(api_key: str, sid: int):
     await check_player(api_key, Privileges.NOMINATOR)
     set = await BeatmapSet.from_bsid(sid)
     if set is None:
         return ORJSONResponse(
-            {"status": "Beatmapset not found."},
-            status_code=status.HTTP_404_NOT_FOUND
+            {"status": "Beatmapset not found."}, status_code=status.HTTP_404_NOT_FOUND,
         )
     await set.force_update()
     return ORJSONResponse(
-        {
-            "status": "Success!",
-            "sid": set.id
-        }, 
-        status_code=status.HTTP_200_OK)
+        {"status": "Success!", "sid": set.id}, status_code=status.HTTP_200_OK,
+    )

--- a/app/api/domains/api.py
+++ b/app/api/domains/api.py
@@ -68,7 +68,8 @@ DATETIME_OFFSET = 0x89F7FF5F7B58000
 
 
 async def check_player(
-    api_key: str, priv: Privileges = Privileges.UNRESTRICTED,
+    api_key: str,
+    priv: Privileges = Privileges.UNRESTRICTED,
 ) -> Player:
     if api_key not in app.state.sessions.api_keys:
         raise HTTPException(status_code=401, detail={"status": "Invaild API Key."})
@@ -959,9 +960,11 @@ async def api_update_maps(api_key: str, sid: int):
     set = await BeatmapSet.from_bsid(sid)
     if set is None:
         return ORJSONResponse(
-            {"status": "Beatmapset not found."}, status_code=status.HTTP_404_NOT_FOUND,
+            {"status": "Beatmapset not found."},
+            status_code=status.HTTP_404_NOT_FOUND,
         )
     await set.force_update()
     return ORJSONResponse(
-        {"status": "Success!", "sid": set.id}, status_code=status.HTTP_200_OK,
+        {"status": "Success!", "sid": set.id},
+        status_code=status.HTTP_200_OK,
     )

--- a/app/commands.py
+++ b/app/commands.py
@@ -735,6 +735,18 @@ async def _map(ctx: Context) -> Optional[str]:
 
     return f"{bmap.embed} updated to {new_status!s}."
 
+@command(Privileges.NOMINATOR, hidden=True)
+async def _update_maps(ctx: Context) -> Optional[str]:
+    if time.time() >= ctx.player.last_np["timeout"]:
+        return "Please /np a map first!"
+
+    bmap = ctx.player.last_np["bmap"]
+    try:
+        await bmap.set.force_update()
+    except:
+        return "An error occurred when updating maps."
+    return "All maps from the set are updated!"
+
 
 """ Mod commands
 # The commands below are somewhat dangerous,

--- a/app/commands.py
+++ b/app/commands.py
@@ -736,19 +736,6 @@ async def _map(ctx: Context) -> Optional[str]:
     return f"{bmap.embed} updated to {new_status!s}."
 
 
-@command(Privileges.NOMINATOR, hidden=True)
-async def _update_maps(ctx: Context) -> Optional[str]:
-    if time.time() >= ctx.player.last_np["timeout"]:
-        return "Please /np a map first!"
-
-    bmap = ctx.player.last_np["bmap"]
-    try:
-        await bmap.set.force_update()
-    except:
-        return "An error occurred when updating maps."
-    return "All maps from the set are updated!"
-
-
 """ Mod commands
 # The commands below are somewhat dangerous,
 # and are generally for managing players.

--- a/app/commands.py
+++ b/app/commands.py
@@ -735,6 +735,7 @@ async def _map(ctx: Context) -> Optional[str]:
 
     return f"{bmap.embed} updated to {new_status!s}."
 
+
 @command(Privileges.NOMINATOR, hidden=True)
 async def _update_maps(ctx: Context) -> Optional[str]:
     if time.time() >= ctx.player.last_np["timeout"]:

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-import asyncio
 
+import asyncio
 import functools
 import hashlib
 from collections import defaultdict
@@ -660,8 +660,10 @@ class BeatmapSet:
                     map_md5s_to_delete.add(old_map.md5)
                 else:
                     new_map = new_maps[old_id]
-                    new_status = RankedStatus.from_osuapi(new_maps[old_id]['approved'])
-                    if old_map.md5 == new_map["file_md5"] and (old_map.frozen or old_map.status == new_status):
+                    new_status = RankedStatus.from_osuapi(new_maps[old_id]["approved"])
+                    if old_map.md5 == new_map["file_md5"] and (
+                        old_map.frozen or old_map.status == new_status
+                    ):
                         # map is the same, make no changes
                         updated_maps.append(old_map)  # TODO: is this needed?
                     else:
@@ -740,12 +742,12 @@ class BeatmapSet:
 
     async def force_update(self) -> None:
         await self._update_if_available()
-        app.state.cache.beatmapset.pop(self.id, None) # drop cache if exist
+        app.state.cache.beatmapset.pop(self.id, None)  # drop cache if exist
         for each_map in self.maps:
-            app.state.cache.beatmap.pop(each_map.md5, None) # drop cache if exist
-            app.state.cache.beatmap.pop(each_map.id, None) # drop cache if exist
-            app.state.cache.unsubmitted.discard(each_map.md5) # drop cache if exist
-            app.state.cache.needs_update.discard(each_map.md5) # drop cache if exist
+            app.state.cache.beatmap.pop(each_map.md5, None)  # drop cache if exist
+            app.state.cache.beatmap.pop(each_map.id, None)  # drop cache if exist
+            app.state.cache.unsubmitted.discard(each_map.md5)  # drop cache if exist
+            app.state.cache.needs_update.discard(each_map.md5)  # drop cache if exist
         osu_file_path = BEATMAPS_PATH / f"{each_map.id}.osu"
         await ensure_local_osu_file(osu_file_path, each_map.id, each_map.md5)
         await asyncio.sleep(0.5)

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -691,7 +691,7 @@ class BeatmapSet:
             self.maps = updated_maps
 
             # save changes to sql
-            
+
             if map_md5s_to_delete:
                 # delete maps
                 await app.state.services.database.execute(
@@ -739,7 +739,6 @@ class BeatmapSet:
                 "DELETE FROM mapsets WHERE id = :set_id",
                 {"set_id": self.id},
             )
-            
 
     async def _save_to_sql(self) -> None:
         """Save the object's attributes into the database."""

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 
 import functools
 import hashlib
@@ -659,15 +660,15 @@ class BeatmapSet:
                     map_md5s_to_delete.add(old_map.md5)
                 else:
                     new_map = new_maps[old_id]
-                    if old_map.md5 != new_map["file_md5"]:
+                    new_status = RankedStatus.from_osuapi(new_maps[old_id]['approved'])
+                    if old_map.md5 == new_map["file_md5"] and (old_map.frozen or old_map.status == new_status):
+                        # map is the same, make no changes
+                        updated_maps.append(old_map)  # TODO: is this needed?
+                    else:
                         # update map from old_maps
                         bmap = old_maps[old_id]
                         bmap._parse_from_osuapi_resp(new_map)
                         updated_maps.append(bmap)
-                    else:
-                        # map is the same, make no changes
-                        updated_maps.append(old_map)  # TODO: is this needed?
-
             # find maps that aren't in our current state, and add them
             for new_id, new_map in new_maps.items():
                 if new_id not in old_maps:
@@ -736,6 +737,18 @@ class BeatmapSet:
                 "DELETE FROM mapsets WHERE id = :set_id",
                 {"set_id": self.id},
             )
+
+    async def force_update(self) -> None:
+        await self._update_if_available()
+        app.state.cache.beatmapset.pop(self.id, None) # drop cache if exist
+        for each_map in self.maps:
+            app.state.cache.beatmap.pop(each_map.md5, None) # drop cache if exist
+            app.state.cache.beatmap.pop(each_map.id, None) # drop cache if exist
+            app.state.cache.unsubmitted.discard(each_map.md5) # drop cache if exist
+            app.state.cache.needs_update.discard(each_map.md5) # drop cache if exist
+        osu_file_path = BEATMAPS_PATH / f"{each_map.id}.osu"
+        await ensure_local_osu_file(osu_file_path, each_map.id, each_map.md5)
+        await asyncio.sleep(0.5)
 
     async def _save_to_sql(self) -> None:
         """Save the object's attributes into the database."""


### PR DESCRIPTION
1. Add a command and api for BN to force updating a map in order to solve some maps stucking in NotSubmitted or UpdateAvailable status.
2. Add plays and playtime as the sort of leaderboard
3. Change the update logic when maps update available (old ways ignored the condition that a qualified map changed to ranked map without md5 changes)