### PR TITLE
chore(api): change default player count on lb from 25 to 50

### DIFF
--- a/app/api/domains/api.py
+++ b/app/api/domains/api.py
@@ -819,7 +819,7 @@ async def api_get_match(
 async def api_get_global_leaderboard(
     sort: Literal["tscore", "rscore", "pp", "acc", "plays", "playtime"] = "pp",
     mode_arg: int = Query(0, alias="mode", ge=0, le=11),
-    limit: int = Query(25, ge=1, le=100),
+    limit: int = Query(50, ge=1, le=100),
     offset: int = Query(0, min=0, max=2_147_483_647),
     country: Optional[str] = Query(None, min_length=2, max_length=2),
     db_conn: databases.core.Connection = Depends(acquire_db_conn),


### PR DESCRIPTION
most places work under the assumption that pages contain 50 players on each page, which also seems more logical to me.

can be closed if too irrelevant but just something i noticed