### PR TITLE
Fix broken seasonal backgrounds

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -1650,7 +1650,7 @@ async def osuMarkAsRead(
 
 @router.get("/web/osu-getseasonal.php")
 async def osuSeasonal():
-    return ORJSONResponse(app.settings.SEASONAL_BGS._items)
+    return ORJSONResponse(app.settings.SEASONAL_BGS)
 
 
 @router.get("/web/bancho_connect.php")


### PR DESCRIPTION
After pulling the last few commits I've noticed seasonal backgrounds don't work and comes up with 

`
File "/home/sensokaku/bancho.py/app/api/domains/osu.py", line 1696, in osuSeasonal                                                                          return ORJSONResponse(app.settings.SEASONAL_BGS._items)
AttributeError: 'list' object has no attribute '_items'
`

And removing _items solved the issue.

I'm not sure if anyone else has gotten the issue (I'm also using ubuntu 22.10 LTS if that could be a factor)