### PR TITLE
feat: nasuya support

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -504,7 +504,7 @@ async def osuSearchHandler(
     if USING_NASUYA:
         # nasuya can serialize to direct for us
         params["osu_direct"] = 1
-   
+
     async with app.state.services.http_client.get(search_url, params=params) as resp:
         if resp.status != status.HTTP_200_OK:
             if USING_CHIMU:

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -503,7 +503,7 @@ async def osuSearchHandler(
 
     if USING_NASUYA:
         # nasuya can serialize to direct for us
-        params["osu_direct"] = 1
+        params["osu_direct"] = True
 
     async with app.state.services.http_client.get(search_url, params=params) as resp:
         if resp.status != status.HTTP_200_OK:


### PR DESCRIPTION
nasuya (https://nasuya.xyz/docs) is a new, efficient mirror created by me, has a cheesegull supporting api (albeit on a different URL). this pr adds support for it, as it adds some conveniences (e.g automatic direct serialization)