### PR TITLE
fix: support empty server port in config

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -20,7 +20,14 @@ MAX_MATCHES = 64
 
 
 SERVER_ADDR = os.environ["SERVER_ADDR"]
-SERVER_PORT = int(os.getenv("SERVER_PORT", 0)) or None
+
+# this is a bit weird, to allow "" as a value for backwards compatibility.
+# perhaps can remove in future.
+_server_port = os.environ["SERVER_PORT"]
+if _server_port:
+    SERVER_PORT = int(_server_port)
+else:
+    SERVER_PORT = None
 
 DB_HOST = os.environ["DB_HOST"]
 DB_PORT = int(os.environ["DB_PORT"])


### PR DESCRIPTION
mostly for backwards compatibility, perhaps we can change the value & eventually deprecate this support