### PR TITLE
add !gdpr command, /get_gdpr_data api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,18 @@ MENU_ONCLICK_URL=https://akatsuki.pw
 DATADOG_API_KEY=
 DATADOG_APP_KEY=
 
+# Used for sending emails from bpy, e.g. GDPR data.
+# If using gmail's smtp, the username is your email
+# and the password is your generated app password.
+# More info: https://support.google.com/mail/answer/185833
+# These settings can also be used with other SMTP servers.
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=465
+SMTP_USERNAME=youremail@gmail.com
+SMTP_PASSWORD=app_password
+SMTP_EMAIL=youremail@gmail.com
+
+
 DEBUG=False
 
 # redirect beatmaps, beatmapsets, and forum

--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -8,16 +8,22 @@ from typing import Literal
 from typing import Optional
 
 from fastapi import APIRouter
+from fastapi import Depends
 from fastapi import status
 from fastapi.param_functions import Query
 from fastapi.responses import ORJSONResponse
 from fastapi.responses import StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials as HTTPCredentials
+from fastapi.security import HTTPBearer
+from starlette.requests import Request
 
 import app.packets
 import app.state
 from app.constants import regexes
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
+from app.constants.privileges import Privileges
+import app.usecases.gdpr
 from app.objects.beatmap import Beatmap
 from app.objects.clan import Clan
 from app.objects.player import Player
@@ -32,6 +38,7 @@ SCREENSHOTS_PATH = SystemPath.cwd() / ".data/ss"
 
 
 router = APIRouter()
+oauth2_scheme = HTTPBearer(auto_error=False)
 
 # NOTE: the api is still under design and is subject to change.
 # to keep up with breaking changes, please either join our discord,
@@ -107,6 +114,39 @@ def format_map_basic(m: Beatmap) -> dict[str, object]:
         "hp": m.hp,
         "diff": m.diff,
     }
+    
+    
+@router.get("/get_gdpr_data")
+async def api_get_gdpr_data(
+    token: HTTPCredentials = Depends(oauth2_scheme),
+    user_id: int = Query(None, alias="id", ge=3, le=2_147_483_647)
+):
+    """Returns the GDPR data of a user as a zip archive."""
+
+    executor_id = app.state.sessions.api_keys.get(token.credentials)
+    if executor_id is None:
+        return ORJSONResponse(
+            {"status": "Invalid API key."},
+            status_code=status.HTTP_401_UNAUTHORIZED,
+        )
+        
+    executor = app.state.sessions.players.from_cache_or_sql(executor_id)
+    if executor.priv & Privileges.DEVELOPER == 0:
+        return ORJSONResponse(
+        {
+            "status": "No permission to access GDPR data.",
+        },
+    )
+
+    zip = await app.usecases.gdpr.generate_zip_archive(user_id)
+    return StreamingResponse(
+        content=zip,
+        media_type="application/octet-stream",
+        headers={
+            "Content-Description": "File Transfer",
+            "Content-Disposition": f'attachment;filename="gdpr_{user_id}.zip"',
+        },
+    )
 
 
 @router.get("/search_players")

--- a/app/commands.py
+++ b/app/commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import copy
 import importlib
 import os
@@ -11,6 +12,7 @@ import struct
 import time
 import traceback
 import uuid
+from multiprocessing import Process
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime
@@ -39,6 +41,7 @@ import app.packets
 import app.settings
 import app.state
 import app.usecases.performance
+import app.usecases.gdpr
 import app.utils
 from app.constants import regexes
 from app.constants.gamemodes import GameMode
@@ -165,6 +168,23 @@ def command(
 # The commands below are not considered dangerous,
 # and are granted to any unbanned players.
 """
+
+
+@command(Privileges.UNRESTRICTED, aliases=["gdpr"])
+async def requestgdpr(ctx: Context) -> Optional[str]:
+    
+    if ctx.recipient is not app.state.sessions.bot:
+        return f"Command only available in DMs with {app.state.sessions.bot.name}."
+    
+    last_request = time.time() - 2000000
+    next_request = last_request + 60 * 60 * 24 * 14
+    
+    if time.time() < next_request:
+        return f"You may only request your GDPR once every two weeks. You can request the next data {timeago.format(next_request)}."
+
+    asyncio.create_task(app.usecases.gdpr.send_gdpr_email(ctx.player))
+    
+    return "Your GDPR data package is being generated and sent to your e-mail. This might take some time."
 
 
 @command(Privileges.UNRESTRICTED, aliases=["", "h"], hidden=True)

--- a/app/constants/regexes.py
+++ b/app/constants/regexes.py
@@ -24,3 +24,5 @@ TOURNEY_MATCHNAME = re.compile(
 MAPPOOL_PICK = re.compile(r"^([a-zA-Z]+)([0-9]+)$")
 
 BEST_OF = re.compile(r"^(?:bo)?(\d{1,2})$")
+
+CHATLOG_USER_ID = r"\((.*?)\)"

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -247,6 +247,8 @@ class Player:
         self.id = id
         self.name = name
         self.safe_name = self.make_safe(self.name)
+        
+        self.email = extras.get("email")
 
         if "pw_bcrypt" in extras:
             self.pw_bcrypt: Optional[bytes] = extras["pw_bcrypt"]

--- a/app/settings.py
+++ b/app/settings.py
@@ -60,6 +60,12 @@ MENU_ONCLICK_URL = os.environ["MENU_ONCLICK_URL"]
 DATADOG_API_KEY = os.environ["DATADOG_API_KEY"]
 DATADOG_APP_KEY = os.environ["DATADOG_APP_KEY"]
 
+SMTP_SERVER = os.environ["SMTP_SERVER"]
+SMTP_PORT = os.environ["SMTP_PORT"]
+SMTP_USERNAME = os.environ["SMTP_USERNAME"]
+SMTP_PASSWORD = os.environ["SMTP_PASSWORD"]
+SMTP_EMAIL = os.environ["SMTP_EMAIL"]
+
 DEBUG = read_bool(os.environ["DEBUG"])
 REDIRECT_OSU_URLS = read_bool(os.environ["REDIRECT_OSU_URLS"])
 

--- a/app/usecases/email.py
+++ b/app/usecases/email.py
@@ -1,0 +1,35 @@
+import smtplib, ssl
+import app.settings
+
+from email.utils import formatdate, COMMASPACE
+from email.mime.text import MIMEText
+from email.mime.message import MIMEMessage
+from email.mime.multipart import MIMEMultipart
+from email.mime.application import MIMEApplication
+
+def send_email(receivers: list[str], subject: str, content, attachments: list[MIMEMessage]):
+    """Sends an email using the specified SMTP settings in the config with the specified subject, content and attachments to the specified receivers"""
+    
+    with smtplib.SMTP_SSL(app.settings.SMTP_SERVER, app.settings.SMTP_PORT, context=ssl.create_default_context()) as server:
+        server.login(app.settings.SMTP_USERNAME, app.settings.SMTP_PASSWORD)
+        
+        msg = MIMEMultipart()
+        msg['From'] = app.settings.SMTP_EMAIL
+        msg['To'] = COMMASPACE.join(receivers)
+        msg['Date'] = formatdate(localtime=True)
+        msg['Subject'] = subject
+        msg.attach(MIMEText(content, "html"))
+        
+        for attachment in attachments:
+            msg.attach(attachment)
+            
+        server.sendmail(app.settings.SMTP_EMAIL, receivers, msg=msg.as_string())
+        
+        
+def get_file_attachment(filename: str, data: bytes) -> MIMEApplication:
+    """Returns the specified bytes with the specified filename as a MIMEApplication attachment."""
+    
+    attachment = MIMEApplication(data)
+    attachment["Content-Disposition"] = f"attachment; filename=\"{filename}\""
+    
+    return attachment

--- a/app/usecases/gdpr.py
+++ b/app/usecases/gdpr.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import csv
+import glob
+import os.path
+import re
+import base64
+import zipfile
+from io import BytesIO
+from io import StringIO
+
+import smtplib, ssl
+import app.settings
+import app.state
+import app.utils
+import app.usecases.email
+from app.constants import regexes
+from app.objects.player import Player
+
+# All user-data related tables and their WHERE query to select the user-related rows
+table_queries = {
+    "clans": "owner = :id",
+    "client_hashes": "userid = :id",
+    "comments": "userid = :id",
+    "favourites": "userid = :id",
+    "ingame_logins": "userid = :id",
+   #"logs": "`from` = :id OR `to` = :id", # critical data
+    "mail": "from_id = :id OR to_id = :id",
+    "map_requests": "player_id = :id",
+    "ratings": "userid = :id",
+    "relationships": "user1 = :id",
+    "scores": "userid = :id",
+    "stats": "id = :id",
+    "users": "id = :id",
+}
+
+
+async def generate_table_csv(table: str, user_id: int) -> str:
+    """Generates the CSV as a string for the specified table from the table dictionary and user id."""
+    if not table in table_queries:
+        raise KeyError("Table not found.")
+
+    output = StringIO()
+    writer = csv.writer(output, strict=True)
+
+    # fetch the column names for the CSV column row
+    columns = await app.state.services.database.fetch_all(
+        f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = :table",
+        {"table": table},
+    )
+
+    writer.writerow(column["COLUMN_NAME"] for column in columns)
+
+    rows = await app.state.services.database.fetch_all(
+        f"SELECT * FROM {table} WHERE {table_queries[table]}",
+        {"id": user_id},
+    )
+
+    for row in rows:
+        writer.writerow(row)
+
+    return output.getvalue()
+
+
+async def generate_csvs(user_id: int) -> dict[str, str]:
+    """Generates all CSVs for all tables in the table dictionary for the specified user id."""
+    csvs = {}
+
+    for table in table_queries.keys():
+        csvs[table] = await generate_table_csv(table, user_id)
+
+    return csvs
+
+
+async def generate_zip_archive(user_id: int) -> BytesIO:
+    """Generates the whole user-data package as a zip archive and returns the BytesIO object."""
+    output = BytesIO()
+
+    with zipfile.ZipFile(output, "a", zipfile.ZIP_STORED, False) as zip:
+
+        # Add the sql data CSV files to the zip archive
+        for table, csv in (await generate_csvs(user_id)).items():
+            zip.writestr(f"data/{table}.csv", csv)
+
+        # Add the user avatar to the zip archive
+        avatars = glob.glob(str(app.utils.DATA_PATH / "avatars") + f"/{user_id}.*")
+        for avatar in avatars:
+            with open(avatar, "rb") as file:
+                zip.writestr(f"{os.path.split(avatar)[-1]}", file.read())
+
+        # Add the chat logs from .data/logs/chat.log
+        chatlog = StringIO()
+        file = open(app.utils.DATA_PATH / "logs/chat.log")
+        while True:
+            line = file.readline()
+            if not line:
+                break
+
+            matches = re.findall(
+                regexes.CHATLOG_USER_ID,
+                ":".join(line.split(":")[:3]),
+            )
+
+            if len(matches) > 0 and matches[0] == str(user_id):
+                chatlog.write(line)
+            if len(matches) > 1 and matches[1] == str(user_id):
+                chatlog.write(line)
+
+        chatlog.seek(0)
+        zip.writestr("chat.log", chatlog.getvalue())
+
+        # Get the score ids of all passed scores of the user and add their replays to the archive
+        # score_ids = await app.state.services.database.fetch_all(
+        #    "SELECT id FROM scores WHERE userid = :userid AND status > 0",
+        #    {"userid": user_id}
+        # )
+        # for id in (x["id"] for x in score_ids):
+        #    with open(app.utils.DATA_PATH / f"osr/{id}.osr", "rb") as file:
+        #        zip.writestr(f"replays/{id}.osr", file.read())
+
+    output.seek(0)
+    return output
+
+
+async def send_gdpr_email(player: Player):
+    """Sends an email containing the GDPR data to the specified user."""
+    
+    zip = (await generate_zip_archive(player.id)).read()
+    attachment = app.usecases.email.get_file_attachment(f"gdpr_{player.id}.zip", zip)
+    
+    message_base64 = "PGxpbmsgaHJlZj0iaHR0cHM6Ly9mb250cy5nb29nbGVhcGlzLmNvbS9jc3M/ZmFtaWx5PVJvYm90bzo0MDAsNzAwIiByZWw9InN0eWxlc2hlZXQiIHR5cGU9InRleHQvY3NzIj48dGFibGUgcm9sZT0icHJlc2VudGF0aW9uIiB3aWR0aD0iMTAwJSIgY2VsbHNwYWNpbmc9IjAiIGNlbGxwYWRkaW5nPSIwIj4gPHRib2R5PiA8dHI+IDx0ZD4gPGgxIHN0eWxlPSJtYXJnaW4tYm90dG9tOiAxMHB4OyB0ZXh0LWFsaWduOiBjZW50ZXI7IGZvbnQtZmFtaWx5OiBSb2JvdG8sIFRhaG9tYSwgc2Fucy1zZXJpZjsgZm9udC1zaXplOiA2NXB4OyI+R0RQUiBSZXF1ZXN0PC9oMT4gPC90ZD48L3RyPjx0cj4gPHRkPiA8aDIgc3R5bGU9Im1hcmdpbi10b3A6IDBweDsgZm9udC1mYW1pbHk6IFJvYm90bywgVGFob21hLCBzYW5zLXNlcmlmOyBmb250LXNpemU6IDI0cHg7IHRleHQtYWxpZ246IGNlbnRlcjsiPkhlbGxvIFtOQU1FXSE8YnIvPllvdXIgR0RQUiBkYXRhIHBhY2thZ2UgaXMgcmVhZHkuPGJyLz5QbGVhc2UgdmlldyB0aGUgYXR0YWNobWVudHMgdG8gZG93bmxvYWQ8YnIvPnRoZSB1bmNvbXByZXNzZWQgWklQIGFyY2hpdmUuPC9oMj4gPC90ZD48L3RyPjx0cj4gPHRkPiA8aDMgc3R5bGU9ImZvbnQtZmFtaWx5OiBSb2JvdG8sIFRhaG9tYSwgc2Fucy1zZXJpZjsgZm9udC1zaXplOiAxOHB4OyBjb2xvcjogIzk1YTVhNjsgdGV4dC1hbGlnbjogY2VudGVyOyI+U2VudCBieSBiYW5jaG8ucHkgdmlhIFtET01BSU5dPC9oMz4gPC90ZD48L3RyPjwvdGJvZHk+PC90YWJsZT4="
+    message = base64.b64decode(message_base64).decode("utf-8")
+    message = message.replace("[NAME]", player.name)
+    message = message.replace("[DOMAIN]", app.settings.DOMAIN)
+    
+    app.usecases.email.send_email([player.email], "Your GDPR data package is ready!", message, [attachment])
+    player.send_bot("Your GDPR data packge has been sent.")


### PR DESCRIPTION
This adds GDPR compliance for bancho.py to work as independently from other services. The gdpr.py in usecases handles collecting the data, converting them to the CSV format and putting them in a zip archive.

With the api endpoint, /get_gdpr_data you can access anyones data by specifying an API key of a user with developer privileges and the user id in the id parameter.

The !gdpr command sends the GDPR zip archive to the email of the user, my utilizing the smtp server specified in the config.
By default, I added google's smtp server as it is free and easy for everyone to set up. All you have to do is open the security settings of your google account to generate an app password for gmail. Then you log into the smtp server with your email and the app password. Server owners can either use their own google account or create a new one. They can also use their own SMTP server if they are hosting one or use Twilio's SMTP service.