### PR TITLE
fix: pre-commit conflicting deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,6 @@ repos:
     rev: 1.13.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==21.11b1]
 
 default_language_version:
     python: python3.9


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

`blacken-docs` was requesting a version of black that is out of date.

## Related Issues / Projects

This PR fixes checks, should be merged immediately.

## Checklist
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style
