### PR TITLE
fix: forget to unpack osu_client_stream enum

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -506,7 +506,7 @@ async def login(
 
         async with services.http_client.get(
             OSU_API_V2_CHANGELOG_URL,
-            params={"stream": osu_client_stream},
+            params={"stream": osu_client_stream.value},
         ) as resp:
             for build in (await resp.json())["builds"]:
                 version = date(


### PR DESCRIPTION
# Related Issues
1. cuttingedge client can't pass allowed client check