### PR TITLE
fix: only allow one space to be stripped from score submission username

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -688,8 +688,13 @@ async def osuSubmitModularSelector(
     if not bmap:
         # Map does not exist, most likely unsubmitted.
         return b"error: beatmap"
+    
+    # if the client has supporter, a space is appended
+    # but usernames may also end with a space, which must be preserved
+    username = score_data[1]
+    if username[-1] == " ":
+        username = username[:-1]
 
-    username = score_data[1].rstrip()  # rstrip 1 space if client has supporter
     player = await app.state.sessions.players.from_login(username, pw_md5)
     if not player:
         # Player is not online, return nothing so that their

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -688,7 +688,7 @@ async def osuSubmitModularSelector(
     if not bmap:
         # Map does not exist, most likely unsubmitted.
         return b"error: beatmap"
-    
+
     # if the client has supporter, a space is appended
     # but usernames may also end with a space, which must be preserved
     username = score_data[1]


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

This change will manually strip the final space of a username to allow score submission on cases where a username ends with a space.

## Related Issues / Projects

Resolves https://github.com/osuAkatsuki/bancho.py/issues/429

## Checklist
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style
