### PR TITLE
fix: pool information being ordered alphabetically and numerically, give full response to user on !pool add success

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -2192,7 +2192,7 @@ async def pool_add(ctx: Context) -> Optional[str]:
     # add to cache
     pool.maps[(mods, slot)] = bmap
 
-    return f"{bmap.embed} added to {name}."
+    return f"{bmap.embed} added to {name} as {mods_slot}."
 
 
 @pool_commands.add(Privileges.TOURNEY_MANAGER, aliases=["rm", "r"], hidden=True)
@@ -2267,8 +2267,8 @@ async def pool_info(ctx: Context) -> Optional[str]:
     datetime_fmt = f"Created at {_time} on {_date}"
     l = [f"{pool.id}. {pool.name}, by {pool.created_by} | {datetime_fmt}."]
 
-    for (mods, slot), bmap in pool.maps.items():
-        l.append(f"{mods!r}{slot}: {bmap.embed}")
+    for (mods, slot), bmap in sorted(pool.maps.items(), key=lambda x: (Mods.to_string(x[0][0]), x[0][1])):
+        l.append(f"{Mods.to_string(mods)}{slot}: {bmap.fullest_embed}")
 
     return "\n".join(l)
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -2271,7 +2271,7 @@ async def pool_info(ctx: Context) -> Optional[str]:
         pool.maps.items(),
         key=lambda x: (Mods.to_string(x[0][0]), x[0][1]),
     ):
-        l.append(f"{mods!r}{slot}: {bmap.full_embed}")
+        l.append(f"{mods!r}{slot}: {bmap.embed}")
 
     return "\n".join(l)
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -2267,7 +2267,9 @@ async def pool_info(ctx: Context) -> Optional[str]:
     datetime_fmt = f"Created at {_time} on {_date}"
     l = [f"{pool.id}. {pool.name}, by {pool.created_by} | {datetime_fmt}."]
 
-    for (mods, slot), bmap in sorted(pool.maps.items(), key=lambda x: (Mods.to_string(x[0][0]), x[0][1])):
+    for (mods, slot), bmap in sorted(
+        pool.maps.items(), key=lambda x: (Mods.to_string(x[0][0]), x[0][1]),
+    ):
         l.append(f"{Mods.to_string(mods)}{slot}: {bmap.fullest_embed}")
 
     return "\n".join(l)

--- a/app/commands.py
+++ b/app/commands.py
@@ -2268,7 +2268,8 @@ async def pool_info(ctx: Context) -> Optional[str]:
     l = [f"{pool.id}. {pool.name}, by {pool.created_by} | {datetime_fmt}."]
 
     for (mods, slot), bmap in sorted(
-        pool.maps.items(), key=lambda x: (Mods.to_string(x[0][0]), x[0][1]),
+        pool.maps.items(),
+        key=lambda x: (Mods.to_string(x[0][0]), x[0][1]),
     ):
         l.append(f"{mods!r}{slot}: {bmap.full_embed}")
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -2270,7 +2270,7 @@ async def pool_info(ctx: Context) -> Optional[str]:
     for (mods, slot), bmap in sorted(
         pool.maps.items(), key=lambda x: (Mods.to_string(x[0][0]), x[0][1]),
     ):
-        l.append(f"{Mods.to_string(mods)}{slot}: {bmap.fullest_embed}")
+        l.append(f"{mods!r}{slot}: {bmap.full_embed}")
 
     return "\n".join(l)
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
i made `!pool info` list alphabetically, then numerically

previous functionality
![alt](https://media.discordapp.net/attachments/1000880937258717235/1107109107128860753/image.png)

new functionality
![alt](https://cdn.discordapp.com/attachments/1000880937258717235/1107113149246734466/osu_R9Cso99LaE.png)

i made `!pool add` list back whatever mod slot the user selected, instead of just the beatmap and pool name

previous functionality
`Peter Lambert - osu! Tutorial added to HWC22.`

new functionality
`Peter Lambert - osu! Tutorial added to HWC22 as HD1.`

please ignore the custom embeds and the "FM" entry. those are not included in this pull request.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style
