### PR TITLE
fix: adjust for breaking changes in pydantic v2

### DIFF
--- a/app/api/v2/common/responses.py
+++ b/app/api/v2/common/responses.py
@@ -7,7 +7,7 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
-from pydantic.generics import GenericModel
+from pydantic import BaseModel
 
 from app.api.v2.common import json
 
@@ -15,7 +15,7 @@ from app.api.v2.common import json
 T = TypeVar("T")
 
 
-class Success(GenericModel, Generic[T]):
+class Success(BaseModel, Generic[T]):
     status: Literal["success"]
     data: T
     meta: dict[str, Any]
@@ -33,7 +33,7 @@ def success(
     return json.ORJSONResponse(data, status_code, headers)
 
 
-class ErrorResponse(GenericModel, Generic[T]):
+class ErrorResponse(BaseModel, Generic[T]):
     status: Literal["error"]
     error: T
     message: str

--- a/app/api/v2/models/__init__.py
+++ b/app/api/v2/models/__init__.py
@@ -12,7 +12,7 @@ T = TypeVar("T", bound=type["BaseModel"])
 
 class BaseModel(_pydantic_BaseModel):
     class Config:
-        anystr_strip_whitespace = True
+        str_strip_whitespace = True
 
     @classmethod
     def from_mapping(cls: T, mapping: Mapping[str, Any]) -> T:


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

recently, fastapi was updated to version 0.100.0, which introduced support for pydantic v2 and brought some breaking changes along with it. for bancho.py, this caused an import error immediately upon launch due to `GenericModel` being replaced by `BaseModel`. upon testing there was also a deprecation warning for the `anystr_strip_whitespace` model attribute, which has now also been renamed. :)

## Related Issues / Projects

the offending fastapi release:
https://github.com/tiangolo/fastapi/releases/tag/0.100.0

pydantic v2 recommended adjustments:
https://github.com/pydantic/bump-pydantic#bp005-replace-genericmodel-by-basemodel

## Checklist
- [x] I've manually tested my code
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style
