### PR TITLE
fix: prevent crash when leaving tournament match channel

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -2002,7 +2002,8 @@ class TourneyMatchLeaveChannel(BasePacket):
 
         # attempt to join match chan
         player.leave_channel(match.chat)
-        match.tourney_clients.remove(player.id)
+        if player.id in match.tourney_clients:
+            match.tourney_clients.remove(player.id)
 
 
 @register(ClientPackets.FRIEND_ADD)

--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -1997,13 +1997,12 @@ class TourneyMatchLeaveChannel(BasePacket):
             return  # insufficient privs
 
         match = app.state.sessions.matches[self.match_id]
-        if not match:
+        if not (match and player.id in match.tourney_clients):
             return  # match not found
 
         # attempt to join match chan
         player.leave_channel(match.chat)
-        if player.id in match.tourney_clients:
-            match.tourney_clients.remove(player.id)
+        match.tourney_clients.remove(player.id)
 
 
 @register(ClientPackets.FRIEND_ADD)


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
This PR fixes crashes caused by the tournament client when removing attempting to remove players who are not in the match.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style

Im having issue running `make lint` in my system from `setuptools` complaining and python wasn't my main language soo it would be nice to know how to run `make lint` properly