### PR TITLE
feat: add docker build/push action

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,46 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: ["master"]
+    paths-ignore: ["**.md", "ext/**", "tools/"]
+  pull_request:
+    branches: ["master"]
+    paths-ignore: ["**.md", "ext/**", "tools/"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.ref == 'refs/heads/master' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/bancho.py:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/docker.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docker
+          path: /tmp/docker.tar

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -3,10 +3,10 @@ name: Build and Publish Docker Image
 on:
   push:
     branches: ["master"]
-    paths-ignore: ["**.md", "ext/**", "tools/"]
+    paths-ignore: ["**.md", "ext/**"]
   pull_request:
     branches: ["master"]
-    paths-ignore: ["**.md", "ext/**", "tools/"]
+    paths-ignore: ["**.md", "ext/**"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

Added a GitHub action for building Docker images. This will output as a job artifact. Additionally, it will push to the Docker registry if the action is on `master`.

Artifacts may be used in other actions like this:

```yml
  use:
    runs-on: ubuntu-latest
    needs: build
    steps:
      - name: Download artifact
        uses: actions/download-artifact@v3
        with:
          name: docker
          path: /tmp
      - name: Load image
        run: |
          docker load --input /tmp/docker.tar
          docker image ls -a     
```

## Related Issues / Projects

#514 

## Checklist
- [x] I've manually tested my code
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style
