### PR TITLE
fix: workaround secrets not available

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
secrets are not available to users without write access to the repo as they are currently configured. with this change this should not be an issue anymore as if you are pushing to master you have write access anyway. we didn't need login unless we were going to build.

<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
- [x] The changes pass pre-commit checks (`make lint`)
- [x] The changes follow coding style
