### PR TITLE
fix: ensure frozen state on database and cache are in sync on !map

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -655,7 +655,7 @@ async def _map(ctx: Context) -> str | None:
             for bmap in app.state.cache.beatmapset[bmap.set_id].maps:
                 bmap.status = new_status
                 bmap.frozen = True
-                
+
             # select all map ids for clearing map requests.
             map_ids = [
                 row["id"]

--- a/app/commands.py
+++ b/app/commands.py
@@ -648,13 +648,13 @@ async def _map(ctx: Context) -> str | None:
     async with app.state.services.database.connection() as db_conn:
         if ctx.args[1] == "set":
             # update all maps in the set
-            for bmap in bmap.set.maps:
-                await maps_repo.update(bmap.id, status=new_status, frozen=True)
+            for _bmap in bmap.set.maps:
+                await maps_repo.update(_bmap.id, status=new_status, frozen=True)
 
             # make sure cache and db are synced about the newest change
-            for bmap in app.state.cache.beatmapset[bmap.set_id].maps:
-                bmap.status = new_status
-                bmap.frozen = True
+            for _bmap in app.state.cache.beatmapset[bmap.set_id].maps:
+                _bmap.status = new_status
+                _bmap.frozen = True
 
             # select all map ids for clearing map requests.
             map_ids = [

--- a/app/commands.py
+++ b/app/commands.py
@@ -647,14 +647,6 @@ async def _map(ctx: Context) -> str | None:
 
     async with app.state.services.database.connection() as db_conn:
         if ctx.args[1] == "set":
-            # select all map ids for clearing map requests.
-            map_ids = [
-                row["id"]
-                for row in await maps_repo.fetch_many(
-                    set_id=bmap.set_id,
-                )
-            ]
-
             # update all maps in the set
             for bmap in bmap.set.maps:
                 await maps_repo.update(bmap.id, status=new_status, frozen=True)
@@ -663,6 +655,14 @@ async def _map(ctx: Context) -> str | None:
             for bmap in app.state.cache.beatmapset[bmap.set_id].maps:
                 bmap.status = new_status
                 bmap.frozen = True
+                
+            # select all map ids for clearing map requests.
+            map_ids = [
+                row["id"]
+                for row in await maps_repo.fetch_many(
+                    set_id=bmap.set_id,
+                )
+            ]
 
         else:
             # update only map

--- a/app/commands.py
+++ b/app/commands.py
@@ -647,7 +647,6 @@ async def _map(ctx: Context) -> str | None:
 
     async with app.state.services.database.connection() as db_conn:
         if ctx.args[1] == "set":
-
             # select all map ids for clearing map requests.
             map_ids = [
                 row["id"]

--- a/app/commands.py
+++ b/app/commands.py
@@ -668,12 +668,12 @@ async def _map(ctx: Context) -> str | None:
             # update only map
             await maps_repo.update(bmap.id, status=new_status, frozen=True)
 
-            map_ids = [bmap.id]
-
             # make sure cache and db are synced about the newest change
             if bmap.md5 in app.state.cache.beatmap:
                 app.state.cache.beatmap[bmap.md5].status = new_status
                 app.state.cache.beatmap[bmap.md5].frozen = True
+
+            map_ids = [bmap.id]
 
         # deactivate rank requests for all ids
         await db_conn.execute(


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

When using the `!map` command to update the status of a beatmap the map is always being frozen. Currently however, the code does set frozen to true in the database, but for the local cache it only updates the status.

I noticed this when debugging #420 and this PR might offer the solution for that issue. I invalidated the cache when debugging (_cache_expired always returned true) which meant it's always being fetched from the api, which caused the status to be reverted because when checking whether it's frozen on the api check it wasn't (since it checks the cache where it was false, not the database where it's true).

## Related Issues / Projects

## Checklist
- [X] I've manually tested my code
- [X] The changes pass pre-commit checks (`make lint`)
- [X] The changes follow coding style
