### PR TITLE
fix: update safe name with name on !changename command

### DIFF
--- a/app/repositories/players.py
+++ b/app/repositories/players.py
@@ -240,6 +240,7 @@ async def update(
     update_fields: PlayerUpdateFields = {}
     if not isinstance(name, _UnsetSentinel):
         update_fields["name"] = name
+        update_fields["safe_name"] = make_safe_name(name)
     if not isinstance(email, _UnsetSentinel):
         update_fields["email"] = email
     if not isinstance(priv, _UnsetSentinel):

--- a/app/repositories/players.py
+++ b/app/repositories/players.py
@@ -66,6 +66,7 @@ class Player(TypedDict):
 
 class PlayerUpdateFields(TypedDict, total=False):
     name: str
+    safe_name: str
     email: str
     priv: int
     country: str


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

This PR introduces significant change to resolve specific issue. The main change is:

- **Adding 'safe_name' Field Update**: I'm introducing an update to the `safe_name` field when updating the `name` field. This resolves the issue where the 'safe_name' field was not correctly updated when using the '!changename' command.

## Checklist
- [x] I've manually tested my code
- [x] The changes follow coding style
