### PR TITLE
fix: `Beatmap.url` returning an incomplete URL

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -1539,7 +1539,9 @@ class MatchChangeSettings(BasePacket):
         elif player.match.map_id == -1:
             if player.match.prev_map_id != self.match_data.map_id:
                 # new map has been chosen, send to match chat.
-                map_url = f"https://osu.{app.settings.DOMAIN}/beatmapsets/#/{self.match_data.map_id}"
+                map_url = (
+                    f"https://osu.{app.settings.DOMAIN}/b/{self.match_data.map_id}"
+                )
                 map_embed = f"[{map_url} {self.match_data.map_name}]"
                 player.match.chat.send_bot(f"Selected: {map_embed}.")
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -352,10 +352,7 @@ async def recent(ctx: Context) -> str | None:
     return " | ".join(l)
 
 
-TOP_SCORE_FMTSTR = (
-    "{idx}. ({pp:.2f}pp) [https://osu.{domain}/beatmapsets/{map_set_id}/{map_id} "
-    "{artist} - {title} [{version}]]"
-)
+TOP_SCORE_FMTSTR = "{idx}. ({pp:.2f}pp) [https://osu.{domain}/b/{map_id} {artist} - {title} [{version}]]"
 
 
 @command(Privileges.UNRESTRICTED, hidden=True)

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -300,7 +300,7 @@ class Beatmap:
     @property
     def url(self) -> str:
         """The osu! beatmap url for `self`."""
-        return f"https://osu.{app.settings.DOMAIN}/beatmap/{self.id}"
+        return f"https://osu.{app.settings.DOMAIN}/b/{self.id}"
 
     @property
     def embed(self) -> str:

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -230,7 +230,7 @@ class Beatmap:
 
     Properties:
       Beatmap.full -> str # Artist - Title [Version]
-      Beatmap.url -> str # https://osu.cmyui.xyz/beatmapsets/123/321
+      Beatmap.url -> str # https://osu.cmyui.xyz/b/321
       Beatmap.embed -> str # [{url} {full}]
 
       Beatmap.has_leaderboard -> bool
@@ -552,7 +552,7 @@ class BeatmapSet:
       BeatmapSet.all_officially_loved() -> bool
 
     Properties:
-      BeatmapSet.url -> str # https://osu.cmyui.xyz/beatmapsets/123
+      BeatmapSet.url -> str # https://osu.cmyui.xyz/s/123
 
     Lower level API:
       await BeatmapSet._from_bsid_cache(bsid: int) -> BeatmapSet | None
@@ -584,9 +584,9 @@ class BeatmapSet:
         return ", ".join(map_names)
 
     @property
-    def url(self) -> str:  # same as above, just no beatmap id
+    def url(self) -> str:
         """The online url for this beatmap set."""
-        return f"https://osu.{app.settings.DOMAIN}/beatmapsets/{self.id}"
+        return f"https://osu.{app.settings.DOMAIN}/s/{self.id}"
 
     def any_beatmaps_have_official_leaderboards(self) -> bool:
         """Whether all the maps in the set have leaderboards on official servers."""

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -300,7 +300,7 @@ class Beatmap:
     @property
     def url(self) -> str:
         """The osu! beatmap url for `self`."""
-        return f"https://osu.{app.settings.DOMAIN}/beatmapsets/{self.set.id}/{self.id}"
+        return f"https://osu.{app.settings.DOMAIN}/beatmap/{self.id}"
 
     @property
     def embed(self) -> str:

--- a/app/objects/match.py
+++ b/app/objects/match.py
@@ -271,7 +271,7 @@ class Match:
     @property
     def map_url(self) -> str:
         """The osu! beatmap url for `self`'s map."""
-        return f"https://osu.{app.settings.DOMAIN}/beatmapsets/#/{self.map_id}"
+        return f"https://osu.{app.settings.DOMAIN}/b/{self.map_id}"
 
     @property
     def embed(self) -> str:


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

`Beatmap.url` returns a URL in the format `/beatmapsets/{self.set.id}/{self.id}`. However, the mode is missing here (e.g. `/beatmapsets/1/75` vs `/beatmapsets/1#osu/75`). Since we don't have an in-built way to get the string of the mode (`mode[:2]` wouldn't work since `catch` is `fruits` here), the easiest way to solve this is by simply using the `/b/{self.id}` format.

## Related Issues / Projects

## Checklist
- [X] I've manually tested my code
