### PR TITLE
fix: cloudflare dns record generator

### DIFF
--- a/tools/generate_cf_dns_records.sh
+++ b/tools/generate_cf_dns_records.sh
@@ -6,16 +6,16 @@ read -p "What's your server IP? " ip
 ip=${ip:-0.0.0.0}
 
 printf '%s\n' \
-    "a.$domain	1	IN	A	$ip"\
-    "api.$domain	1	IN	A	$ip"\
-    "assets.$domain	1	IN	A	$ip"\
-    "b.$domain	1	IN	A	$ip"\
-    "c.$domain	1	IN	A	$ip"\
-    "c4.$domain	1	IN	A	$ip"\
-    "ce.$domain	1	IN	A	$ip"\
+    "a	1	IN	A	$ip"\
+    "api	1	IN	A	$ip"\
+    "assets	1	IN	A	$ip"\
+    "b	1	IN	A	$ip"\
+    "c	1	IN	A	$ip"\
+    "c4	1	IN	A	$ip"\
+    "ce	1	IN	A	$ip"\
     "$domain	1	IN	A	$ip"\
-    "i.$domain	1	IN	A	$ip"\
-    "osu.$domain	1	IN	A	$ip"\
-    "s.$domain	1	IN	A	$ip" >> "cf_records.txt"
+    "i	1	IN	A	$ip"\
+    "osu	1	IN	A	$ip"\
+    "s	1	IN	A	$ip" >> "cf_records.txt"
 
 printf "Your Cloudflare DNS records have been generated."


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
Removed the main domain being added to the subdomains in the cloudflare DNS record generator. Importing it before this fix will cause CF to think it's a large subdomain (ex. `c.example.com.example.com`).

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
