### PR TITLE
Per-checksum score submission locks to prevent score duplicates

### DIFF
--- a/app/state/__init__.py
+++ b/app/state/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+from collections import defaultdict
 from typing import Literal
 from typing import TYPE_CHECKING
 
@@ -13,6 +15,7 @@ if TYPE_CHECKING:
     from app.packets import BasePacket
 
 loop: AbstractEventLoop
+score_submission_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 packets: dict[Literal["all", "restricted"], dict[ClientPackets, type[BasePacket]]] = {
     "all": {},
     "restricted": {},


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
There is an ongoing issue due to this TOCTOU bug where scores (with identical checksums) may submit more than a single time (and award duplicate pp/score/etc.) if multiple get between the start and end conditions simultaneously.

This change adds a concurrency lock around the affected area to ensure only one runs at a time.

## Related Issues / Projects

## Checklist
- [ ] I've manually tested my code
