### PR TITLE
fix: cast `__eq__` to bool

### DIFF
--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -302,7 +302,7 @@ class Player:
 
     @property
     def is_online(self) -> bool:
-        return self.token != ""
+        return bool(self.token != "")
 
     @property
     def url(self) -> str:


### PR DESCRIPTION


<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

This is to appease to mypy as `__eq__` technically returns `Any`. Python casts to bool anyway so this should have 0 impact other than silencing mypy.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
