### PR TITLE
fix: Wrong index for fetching global & country rank from redis on API `/get_player_info`

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -271,13 +271,13 @@ async def api_get_player_info(
         # get all stats
         all_stats = await stats_repo.fetch_many(player_id=resolved_user_id)
 
-        for idx, mode_stats in enumerate(all_stats):
+        for mode_stats in all_stats:
             rank = await app.state.services.redis.zrevrank(
-                f"bancho:leaderboard:{idx}",
+                f"bancho:leaderboard:{mode_stats['mode']}",
                 str(resolved_user_id),
             )
             country_rank = await app.state.services.redis.zrevrank(
-                f"bancho:leaderboard:{idx}:{resolved_country}",
+                f"bancho:leaderboard:{mode_stats['mode']}:{resolved_country}",
                 str(resolved_user_id),
             )
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

The code enumerated through the stats dictionary of the user, but used the index in that enumeration for the mode key instead of the actual mode value, which works fine... Up until autopilot, since the 7 (rx!mania) is skipped and 8 is the proper number to use. This caused the API to give 0 rank for autopilot for any user.

## Checklist
- [X] I've manually tested my code
