### PR TITLE
fix: only run the push portion of the lint action when on master

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,6 +1,8 @@
 name: Lint
 on:
   push:
+    branches:
+      - master
     paths:
       - "**.py"
   pull_request:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,8 +6,6 @@ on:
     paths:
       - "**.py"
   pull_request:
-    paths:
-      - "**.py"
 
 jobs:
   mypy:


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
