### PR TITLE
Reduce duplication issues with map nomination requests

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -541,6 +541,14 @@ async def request(ctx: Context) -> str | None:
     if bmap.status != RankedStatus.Pending:
         return "Only pending maps may be requested for status change."
 
+    map_requests = await map_requests_repo.fetch_all(
+        map_id=bmap.id,
+        player_id=ctx.player.id,
+        active=True,
+    )
+    if map_requests:
+        return "You already have an active nomination request for that map."
+
     await map_requests_repo.create(map_id=bmap.id, player_id=ctx.player.id, active=True)
 
     return "Request submitted."

--- a/app/commands.py
+++ b/app/commands.py
@@ -594,7 +594,7 @@ async def requests(ctx: Context) -> str | None:
 
     l = [f"Total requested beatmaps: {len(grouped)}"]
     for map_id, reviews in grouped.items():
-        assert len(reviews) != 1
+        assert len(reviews) != 0
 
         bmap = await Beatmap.from_bid(map_id)
         if not bmap:

--- a/app/commands.py
+++ b/app/commands.py
@@ -612,7 +612,7 @@ async def requests(ctx: Context) -> str | None:
         first_review = min(reviews, key=lambda r: r["datetime"])
 
         l.append(
-            f"[{bmap.embed}] ({len(reviews)} requests, from {first_review['datetime']:%Y-%m-%d})",
+            f"{len(reviews)}x request(s) starting {first_review['datetime']:%Y-%m-%d}: {bmap.embed}",
         )
 
     return "\n".join(l)

--- a/app/repositories/map_requests.py
+++ b/app/repositories/map_requests.py
@@ -67,7 +67,7 @@ async def create(
 async def fetch_all(
     map_id: int | None = None,
     player_id: int | None = None,
-    active: int | None = None,
+    active: bool | None = None,
 ) -> list[MapRequest]:
     """Fetch a list of map requests from the database."""
     query = f"""\

--- a/app/repositories/map_requests.py
+++ b/app/repositories/map_requests.py
@@ -94,7 +94,7 @@ async def mark_batch_as_inactive(map_ids: list[Any]) -> list[MapRequest]:
            SET active = False
          WHERE map_id IN :map_ids
     """
-    params = {"map_id": map_ids}
+    params = {"map_ids": map_ids}
     await app.state.services.database.execute(query, params)
 
     query = f"""\


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

There are two changes introduced in this PR:
1. Group nomination requests by beatmap in the `!requests` command output. Display count of times requested, rather than individual player requests.
2. Disallow duplicate nomination requests for unique key `(map_id, player_id)`.

Sample command usage after the change:
```
22:30 cmyui: !requests
22:30 BanchoBot: The queue is clean! (0 map request(s)) | Elapsed: 870.11 μsec
22:30 *cmyui is listening to [https://osu.cmyui.xyz/beatmapsets/521936#/1820817 DJ TOTTO - Crystalia]
22:30 cmyui: !request
22:30 BanchoBot: Request submitted. | Elapsed: 22.58 msec
22:30 cmyui: !request
22:30 BanchoBot: You already have an active nomination request for that map. | Elapsed: 1.11 msec
22:30 cmyui: !requests
22:30 BanchoBot: Total requested beatmaps: 1
1x request(s) starting 2024-02-13: [https://osu.cmyui.xyz/b/1820817 DJ TOTTO - Crystalia [Extra 2018]] | Elapsed: 1.06 msec
22:30 cmyui: !map rank map
22:30 BanchoBot: [https://osu.cmyui.xyz/b/1820817 DJ TOTTO - Crystalia [Extra 2018]] updated to Ranked. | Elapsed: 26.47 msec
22:30 cmyui: !requests
22:30 BanchoBot: The queue is clean! (0 map request(s)) | Elapsed: 1.05 msec
22:32 cmyui: !request
22:32 BanchoBot: Only pending maps may be requested for status change. | Elapsed: 24.20 μsec
```

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
