### PR TITLE
Split `MapPools` and related collections/cache into repositories

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1003,11 +1003,12 @@ async def api_get_pool(
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
-    tourney_pool_maps = {
-        (m["mods"], m["slot"]): await Beatmap.from_bid(m["map_id"])
-        for m in await tourney_pool_maps_repo.fetch_many(pool_id=pool_id)
-    }
-    tourney_pool_maps = {k: v for k, v in tourney_pool_maps.items() if v is not None}
+    tourney_pool_maps: dict[tuple[int, int], Beatmap] = {}
+    for pool_map in await tourney_pool_maps_repo.fetch_many(pool_id=pool_id):
+        bmap = await Beatmap.from_bid(pool_map["map_id"])
+        if bmap is not None:
+            tourney_pool_maps[(pool_map["mods"], pool_map["slot"])] = bmap
+
     pool_creator = app.state.sessions.players.get(id=tourney_pool["created_by"])
 
     if pool_creator is None:

--- a/app/commands.py
+++ b/app/commands.py
@@ -1779,8 +1779,11 @@ async def mp_condition(ctx: Context, match: Match) -> str | None:
 @ensure_match
 async def mp_scrim(ctx: Context, match: Match) -> str | None:
     """Start a scrim in the current match."""
+    if len(ctx.args) != 1:
+        return "Invalid syntax: !mp scrim <bo#>"
+
     r_match = regexes.BEST_OF.fullmatch(ctx.args[0])
-    if len(ctx.args) != 1 or not r_match:
+    if not r_match:
         return "Invalid syntax: !mp scrim <bo#>"
 
     best_of = int(r_match[1])

--- a/app/commands.py
+++ b/app/commands.py
@@ -49,7 +49,6 @@ from app.objects.beatmap import Beatmap
 from app.objects.beatmap import RankedStatus
 from app.objects.beatmap import ensure_osu_file_is_available
 from app.objects.clan import Clan
-from app.objects.match import MapPool
 from app.objects.match import Match
 from app.objects.match import MatchTeams
 from app.objects.match import MatchTeamTypes

--- a/app/commands.py
+++ b/app/commands.py
@@ -2245,13 +2245,13 @@ async def pool_info(ctx: Context) -> str | None:
 
     for tourney_map in sorted(
         await tourney_pool_maps_repo.fetch_many(pool_id=tourney_pool["id"]),
-        key=lambda x: (repr(x["mods"]), x["slot"]),
+        key=lambda x: (repr(Mods(x["mods"])), x["slot"]),
     ):
         bmap = await Beatmap.from_bid(tourney_map["map_id"])
         if bmap is None:
             log(f"Could not find beatmap {tourney_map['map_id']}.", Ansi.LRED)
             continue
-        l.append(f"{tourney_map['mods']}{tourney_map['slot']}: {bmap.embed}")
+        l.append(f"{Mods(tourney_map['mods'])!r}{tourney_map['slot']}: {bmap.embed}")
 
     return "\n".join(l)
 

--- a/app/repositories/tourney_pool_maps.py
+++ b/app/repositories/tourney_pool_maps.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import textwrap
+from typing import Any
+from typing import TypedDict
+from typing import cast
+
+import app.state.services
+
+# +---------+---------+------+-----+---------+-------+
+# | Field   | Type    | Null | Key | Default | Extra |
+# +---------+---------+------+-----+---------+-------+
+# | map_id  | int     | NO   | PRI | NULL    |       |
+# | pool_id | int     | NO   | PRI | NULL    |       |
+# | mods    | int     | NO   |     | NULL    |       |
+# | slot    | tinyint | NO   |     | NULL    |       |
+# +---------+---------+------+-----+---------+-------+
+
+
+class TourneyPoolMap(TypedDict):
+    map_id: int
+    pool_id: int
+    mods: int
+    slot: int
+
+
+READ_PARAMS = textwrap.dedent(
+    """\
+        map_id, pool_id, mods, slot
+    """,
+)
+
+
+async def create(map_id: int, pool_id: int, mods: int, slot: int) -> TourneyPoolMap:
+    """Create a new map pool entry in the database."""
+    query = f"""\
+        INSERT INTO tourney_pool_maps (map_id, pool_id, mods, slot)
+             VALUES (:map_id, :pool_id, :mods, :slot)
+    """
+    params: dict[str, Any] = {
+        "map_id": map_id,
+        "pool_id": pool_id,
+        "mods": mods,
+        "slot": slot,
+    }
+    await app.state.services.database.execute(query, params)
+
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pool_maps
+         WHERE map_id = :map_id
+           AND pool_id = :pool_id
+           AND mods = :mods
+           AND slot = :slot
+    """
+    params = {
+        "map_id": map_id,
+        "pool_id": pool_id,
+        "mods": mods,
+        "slot": slot,
+    }
+    tourney_pool_map = await app.state.services.database.fetch_one(query, params)
+
+    assert tourney_pool_map is not None
+    return cast(TourneyPoolMap, dict(tourney_pool_map._mapping))
+
+
+async def fetch_many(
+    pool_id: int | None = None,
+    mods: int | None = None,
+    slot: int | None = None,
+    page: int | None = 1,
+    page_size: int | None = 50,
+) -> list[TourneyPoolMap]:
+    """Fetch a list of map pool entries from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pool_maps
+         WHERE pool_id = COALESCE(:pool_id, pool_id)
+           AND mods = COALESCE(:mods, mods)
+           AND slot = COALESCE(:slot, slot)
+    """
+    params: dict[str, Any] = {
+        "pool_id": pool_id,
+        "mods": mods,
+        "slot": slot,
+    }
+    if page and page_size:
+        query += """\
+            LIMIT :limit
+           OFFSET :offset
+        """
+        params["limit"] = page_size
+        params["offset"] = (page - 1) * page_size
+    tourney_pool_maps = await app.state.services.database.fetch_all(query, params)
+    return cast(
+        list[TourneyPoolMap],
+        [dict(tourney_pool_map._mapping) for tourney_pool_map in tourney_pool_maps],
+    )
+
+
+async def fetch_by_pool_and_pick(
+    pool_id: int,
+    mods: int,
+    slot: int,
+) -> TourneyPoolMap | None:
+    """Fetch a map pool entry by pool and pick from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pool_maps
+         WHERE pool_id = :pool_id
+           AND mods = :mods
+           AND slot = :slot
+    """
+    params: dict[str, Any] = {
+        "pool_id": pool_id,
+        "mods": mods,
+        "slot": slot,
+    }
+    tourney_pool_map = await app.state.services.database.fetch_one(query, params)
+    if tourney_pool_map is None:
+        return None
+    return cast(TourneyPoolMap, dict(tourney_pool_map._mapping))
+
+
+async def delete_map_from_pool(pool_id: int, map_id: int) -> TourneyPoolMap | None:
+    """Delete a map pool entry from a given tourney pool from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pool_maps
+         WHERE pool_id = :pool_id
+           AND map_id = :map_id
+    """
+    params: dict[str, Any] = {
+        "pool_id": pool_id,
+        "map_id": map_id,
+    }
+    tourney_pool_map = await app.state.services.database.fetch_one(query, params)
+    if tourney_pool_map is None:
+        return None
+
+    query = f"""\
+        DELETE FROM tourney_pool_maps
+              WHERE pool_id = :pool_id
+                AND map_id = :map_id
+    """
+    params = {
+        "pool_id": pool_id,
+        "map_id": map_id,
+    }
+    await app.state.services.database.execute(query, params)
+    return cast(TourneyPoolMap, dict(tourney_pool_map._mapping))
+
+
+async def delete_all_in_pool(pool_id: int) -> list[TourneyPoolMap]:
+    """Delete all map pool entries from a given tourney pool from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pool_maps
+         WHERE pool_id = :pool_id
+    """
+    params: dict[str, Any] = {
+        "pool_id": pool_id,
+    }
+    tourney_pool_maps = await app.state.services.database.fetch_all(query, params)
+    if not tourney_pool_maps:
+        return []
+
+    query = f"""\
+        DELETE FROM tourney_pool_maps
+              WHERE pool_id = :pool_id
+    """
+    params = {
+        "pool_id": pool_id,
+    }
+    await app.state.services.database.execute(query, params)
+    return cast(
+        list[TourneyPoolMap],
+        [dict(tourney_pool_map._mapping) for tourney_pool_map in tourney_pool_maps],
+    )

--- a/app/repositories/tourney_pools.py
+++ b/app/repositories/tourney_pools.py
@@ -59,7 +59,7 @@ async def create(name: str, created_by: int) -> TourneyPool:
 
 
 async def fetch_many(
-    pool_id: int | None = None,
+    id: int | None = None,
     created_by: int | None = None,
     page: int | None = 1,
     page_size: int | None = 50,
@@ -67,11 +67,11 @@ async def fetch_many(
     query = f"""\
         SELECT {READ_PARAMS}
           FROM tourney_pools
-          WHERE pool_id = COALESCE(:pool_id, pool_id)
+          WHERE id = COALESCE(:id, id)
             AND created_by = COALESCE(:created_by, created_by)
     """
     params: dict[str, Any] = {
-        "pool_id": pool_id,
+        "id": id,
         "created_by": created_by,
     }
     if page and page_size:

--- a/app/repositories/tourney_pools.py
+++ b/app/repositories/tourney_pools.py
@@ -115,7 +115,9 @@ async def fetch_by_id(id: int) -> TourneyPool | None:
     }
     tourney_pool = await app.state.services.database.fetch_one(query, params)
     return (
-        None if tourney_pool is None else cast(TourneyPool, dict(tourney_pool._mapping))
+        cast(TourneyPool, dict(tourney_pool._mapping))
+        if tourney_pool is not None
+        else None
     )
 
 

--- a/app/repositories/tourney_pools.py
+++ b/app/repositories/tourney_pools.py
@@ -87,7 +87,7 @@ async def fetch_many(
     ]
 
 
-async def fetch_by_name(name: str) -> TourneyPool:
+async def fetch_by_name(name: str) -> TourneyPool | None:
     """Fetch a tourney pool by name from the database."""
     query = f"""\
         SELECT {READ_PARAMS}
@@ -98,9 +98,11 @@ async def fetch_by_name(name: str) -> TourneyPool:
         "name": name,
     }
     tourney_pool = await app.state.services.database.fetch_one(query, params)
-
-    assert tourney_pool is not None
-    return cast(TourneyPool, dict(tourney_pool._mapping))
+    return (
+        cast(TourneyPool, dict(tourney_pool._mapping))
+        if tourney_pool is not None
+        else None
+    )
 
 
 async def fetch_by_id(id: int) -> TourneyPool | None:

--- a/app/repositories/tourney_pools.py
+++ b/app/repositories/tourney_pools.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import textwrap
+from datetime import datetime
+from typing import Any
+from typing import TypedDict
+from typing import cast
+
+import app.state.services
+
+# +------------+-------------+------+-----+---------+----------------+
+# | Field      | Type        | Null | Key | Default | Extra          |
+# +------------+-------------+------+-----+---------+----------------+
+# | id         | int         | NO   | PRI | NULL    | auto_increment |
+# | name       | varchar(16) | NO   |     | NULL    |                |
+# | created_at | datetime    | NO   |     | NULL    |                |
+# | created_by | int         | NO   | MUL | NULL    |                |
+# +------------+-------------+------+-----+---------+----------------+
+
+
+class TourneyPool(TypedDict):
+    id: int
+    name: str
+    created_at: datetime
+    created_by: int
+
+
+READ_PARAMS = textwrap.dedent(
+    """\
+        id, name, created_at, created_by
+    """,
+)
+
+
+async def create(name: str, created_by: int) -> TourneyPool:
+    """Create a new tourney pool entry in the database."""
+    query = f"""\
+        INSERT INTO tourney_pools (name, created_at, created_by)
+             VALUES (:name, NOW(), :user_id)
+    """
+    params: dict[str, Any] = {
+        "name": name,
+        "user_id": created_by,
+    }
+    rec_id = await app.state.services.database.execute(query, params)
+
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pools
+         WHERE id = :id
+    """
+    params = {
+        "id": rec_id,
+    }
+    tourney_pool = await app.state.services.database.fetch_one(query, params)
+
+    assert tourney_pool is not None
+    return cast(TourneyPool, dict(tourney_pool._mapping))
+
+
+async def fetch_many(
+    pool_id: int | None = None,
+    created_by: int | None = None,
+    page: int | None = 1,
+    page_size: int | None = 50,
+) -> list[TourneyPool]:
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pools
+          WHERE pool_id = COALESCE(:pool_id, pool_id)
+            AND created_by = COALESCE(:created_by, created_by)
+    """
+    params: dict[str, Any] = {
+        "pool_id": pool_id,
+        "created_by": created_by,
+    }
+    if page and page_size:
+        query += """\
+            LIMIT :limit
+           OFFSET :offset
+        """
+        params["limit"] = page_size
+        params["offset"] = (page - 1) * page_size
+    tourney_pools = await app.state.services.database.fetch_all(query, params)
+    return [
+        cast(TourneyPool, dict(tourney_pool._mapping)) for tourney_pool in tourney_pools
+    ]
+
+
+async def fetch_by_name(name: str) -> TourneyPool:
+    """Fetch a tourney pool by name from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pools
+         WHERE name = :name
+    """
+    params: dict[str, Any] = {
+        "name": name,
+    }
+    tourney_pool = await app.state.services.database.fetch_one(query, params)
+
+    assert tourney_pool is not None
+    return cast(TourneyPool, dict(tourney_pool._mapping))
+
+
+async def fetch_by_id(id: int) -> TourneyPool | None:
+    """Fetch a tourney pool by id from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pools
+         WHERE id = :id
+    """
+    params: dict[str, Any] = {
+        "id": id,
+    }
+    tourney_pool = await app.state.services.database.fetch_one(query, params)
+    return (
+        None if tourney_pool is None else cast(TourneyPool, dict(tourney_pool._mapping))
+    )
+
+
+async def delete_by_id(id: int) -> TourneyPool | None:
+    """Delete a tourney pool by id from the database."""
+    query = f"""\
+        SELECT {READ_PARAMS}
+          FROM tourney_pools
+         WHERE id = :id
+    """
+    params: dict[str, Any] = {
+        "id": id,
+    }
+    tourney_pool = await app.state.services.database.fetch_one(query, params)
+    if tourney_pool is None:
+        return None
+
+    query = f"""\
+        DELETE FROM tourney_pools
+              WHERE id = :id
+    """
+    params = {
+        "id": id,
+    }
+    await app.state.services.database.execute(query, params)
+    return cast(TourneyPool, dict(tourney_pool._mapping))

--- a/app/state/sessions.py
+++ b/app/state/sessions.py
@@ -8,17 +8,14 @@ from app.logging import Ansi
 from app.logging import log
 from app.objects.collections import Channels
 from app.objects.collections import Clans
-from app.objects.collections import MapPools
 from app.objects.collections import Matches
 from app.objects.collections import Players
 
 if TYPE_CHECKING:
-    from app.objects.achievement import Achievement
     from app.objects.player import Player
 
 players = Players()
 channels = Channels()
-pools = MapPools()
 clans = Clans()
 matches = Matches()
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

This PR acts to serve as an example of how to split objects/collections into repositories.

In this example, the data was simply moved out of application memory and now only exists in the SQL database. I suspect the implementation for `clans` will be very similar, as clans are made up only of persistent data (clans and clan members).

The implementation of `channels` will be somewhat similar -- because similarly there are channels and channel members, however channel members are ephemeral.

The `matches` will be a bit different - in the current bancho.py model, they're entirely ephermeral data which only exists until the server reboots. They should likely be moved to redis in the long-term, but could stay in application memory and still be encapsulated in a repository. Either would be acceptable for a PR.

Splitting up `players` will be the trickiest bit, as I think we should divide the persistent and ephemeral pieces of a player up into separate repositories - the `accounts` and the `sessions`.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
