### PR TITLE
Gracefully handle no match host on lobby join case; add debug logs

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -1318,7 +1318,16 @@ class LobbyJoin(BasePacket):
 
         for match in app.state.sessions.matches:
             if match is not None:
-                player.enqueue(app.packets.new_match(match))
+                try:
+                    player.enqueue(app.packets.new_match(match))
+                except ValueError:
+                    log(
+                        f"Failed to send match {match.id} to player joining lobby; likely due to missing host",
+                        Ansi.LYELLOW,
+                    )
+                    stacktrace = app.utils.get_appropriate_stacktrace()
+                    await app.state.services.log_strange_occurrence(stacktrace)
+                    continue
 
 
 def validate_match_data(

--- a/app/objects/match.py
+++ b/app/objects/match.py
@@ -259,10 +259,13 @@ class Match:
 
         self.tourney_clients: set[int] = set()  # player ids
 
-    @property  # TODO: test cache speed
+    @property
     def host(self) -> Player:
         player = app.state.sessions.players.get(id=self.host_id)
-        assert player is not None
+        if player is None:
+            raise ValueError(
+                f"Host with id {self.host_id} not found for match {self!r}",
+            )
         return player
 
     @property


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

There's an ongoing issue users have reported where `host` may not correctly resolve for an active match in the `LobbyJoin` packet. Multiple server owners (@minisbett, @HorizonCode, among others) have reported this issue on numerous occasions. I've never been able to replicate this, and I've traced the code and am not sure of the root cause.

![image](https://github.com/osuAkatsuki/bancho.py/assets/17343631/2287b35d-b94f-42b1-aaf1-63cc16323797)

This PR will stop the bleeding and not break players who encounter the issue, as well as logging to console (& my debug server if the server owner chooses to share this data with us).

I hope to more "correctly" resolve the information once we have the information to debug the issue.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
