### PR TITLE
Change gatari.pw to configured download endpoint

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -308,9 +308,7 @@ async def maplink(ctx: Context) -> str | None:
     if bmap is None:
         return "No map found!"
 
-    # gatari.pw & nerina.pw are pretty much the only
-    # reliable mirrors I know of? perhaps beatconnect
-    return f"[https://osu.gatari.pw/d/{bmap.set_id} {bmap.full_name}]"
+    return f"[{app.settings.MIRROR_DOWNLOAD_ENDPOINT}/{bmap.set_id} {bmap.full_name}]"
 
 
 @command(Privileges.UNRESTRICTED, aliases=["last", "r"])


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

Changed the hard-coded gatari.pw download link on the !maplink command to the download link of the configured download mirror.

## Checklist
- [x] I've manually tested my code
