### PR TITLE
fix: add rounding to score on getscores

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -1393,7 +1393,7 @@ async def getScores(
                 **personal_best_score_row,
                 name=player.full_name,
                 userid=player.id,
-                score=int(personal_best_score_row["_score"]),
+                score=int(round(personal_best_score_row["_score"])),
                 has_replay="1",
             ),
         )
@@ -1404,7 +1404,7 @@ async def getScores(
         [
             SCORE_LISTING_FMTSTR.format(
                 **s,
-                score=int(s["_score"]),
+                score=int(round(s["_score"])),
                 has_replay="1",
                 rank=idx + 1,
             )


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

Usually PP is always rounded, but on the `/web/osu-osz2-getscores.php` endpoint it's always just casted to an int, resulting in a different PP value than what's displayed elsewhere.

## Checklist
- [x] I've manually tested my code 
