### PR TITLE
Remove unnecessary features to decrease maintenance/complexity overhead. + Cleanup & more repo usage.

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -1593,9 +1593,16 @@ async def get_screenshot(
             status_code=status.HTTP_404_NOT_FOUND,
         )
 
+    if extension in ("jpg", "jpeg"):
+        media_type = "image/jpeg"
+    elif extension == "png":
+        media_type = "image/png"
+    else:
+        media_type = None
+
     return FileResponse(
         path=screenshot_path,
-        media_type=app.utils.get_media_type(extension),
+        media_type=media_type,
     )
 
 

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import os
 import pprint
+import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any
@@ -69,7 +71,9 @@ class BanchoAPI(FastAPI):
 
 @asynccontextmanager
 async def lifespan(asgi_app: BanchoAPI) -> AsyncIterator[Never]:
-    app.utils.setup_runtime_environment()
+    if isinstance(sys.stdout, io.TextIOWrapper):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     app.utils.ensure_supported_platform()
     app.utils.ensure_directory_structure()
 

--- a/app/api/init_api.py
+++ b/app/api/init_api.py
@@ -74,10 +74,10 @@ async def lifespan(asgi_app: BanchoAPI) -> AsyncIterator[Never]:
     if isinstance(sys.stdout, io.TextIOWrapper):
         sys.stdout.reconfigure(encoding="utf-8")
 
-    app.utils.ensure_supported_platform()
-    app.utils.ensure_directory_structure()
+    app.utils.ensure_persistent_volumes_are_available()
 
     app.state.loop = asyncio.get_running_loop()
+
     if app.utils.is_running_as_admin():
         log(
             "Running the server with root privileges is not recommended.",

--- a/app/bg_loops.py
+++ b/app/bg_loops.py
@@ -10,8 +10,6 @@ from app.constants.privileges import Privileges
 from app.logging import Ansi
 from app.logging import log
 
-__all__ = ("initialize_housekeeping_tasks",)
-
 OSU_CLIENT_MIN_PING_INTERVAL = 300000 // 1000  # defined by osu!
 
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -15,6 +15,7 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from datetime import timedelta
 from functools import wraps
 from pathlib import Path
 from time import perf_counter_ns as clock_ns
@@ -1258,7 +1259,7 @@ async def server(ctx: Context) -> str | None:
 
     return "\n".join(
         (
-            f"{build_str} | uptime: {seconds_readable(uptime)}",
+            f"{build_str} | uptime: {timedelta(seconds=uptime)}",
             f"cpu: {cpu_info_str}",
             f"ram: {ram_info}",
             f"search mirror: {mirror_search_url} | download mirror: {mirror_download_url}",

--- a/app/commands.py
+++ b/app/commands.py
@@ -65,7 +65,6 @@ from app.repositories import players as players_repo
 from app.repositories import tourney_pool_maps as tourney_pool_maps_repo
 from app.repositories import tourney_pools as tourney_pools_repo
 from app.usecases.performance import ScoreParams
-from app.utils import seconds_readable
 
 if TYPE_CHECKING:
     from app.objects.channel import Channel

--- a/app/constants/clientflags.py
+++ b/app/constants/clientflags.py
@@ -6,8 +6,6 @@ from enum import unique
 from app.utils import escape_enum
 from app.utils import pymysql_encode
 
-__all__ = ("ClientFlags",)
-
 
 @unique
 @pymysql_encode(escape_enum)

--- a/app/constants/gamemodes.py
+++ b/app/constants/gamemodes.py
@@ -8,8 +8,6 @@ from app.constants.mods import Mods
 from app.utils import escape_enum
 from app.utils import pymysql_encode
 
-__all__ = ("GAMEMODE_REPR_LIST", "GameMode")
-
 GAMEMODE_REPR_LIST = (
     "vn!std",
     "vn!taiko",

--- a/app/constants/mods.py
+++ b/app/constants/mods.py
@@ -7,10 +7,6 @@ from enum import unique
 from app.utils import escape_enum
 from app.utils import pymysql_encode
 
-__all__ = ("Mods",)
-
-# NOTE: the order of some of these = stupid
-
 
 @unique
 @pymysql_encode(escape_enum)

--- a/app/constants/privileges.py
+++ b/app/constants/privileges.py
@@ -7,8 +7,6 @@ from enum import unique
 from app.utils import escape_enum
 from app.utils import pymysql_encode
 
-__all__ = ("Privileges", "ClientPrivileges", "ClanPrivileges")
-
 
 @unique
 @pymysql_encode(escape_enum)

--- a/app/constants/regexes.py
+++ b/app/constants/regexes.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import re
 
-__all__ = ("OSU_VERSION", "USERNAME", "EMAIL", "BEST_OF")
-
-
 OSU_VERSION = re.compile(
     r"^b(?P<date>\d{8})(?:\.(?P<revision>\d))?"
     r"(?P<stream>beta|cuttingedge|dev|tourney)?$",

--- a/app/discord.py
+++ b/app/discord.py
@@ -10,20 +10,6 @@ from tenacity import wait_exponential
 
 from app.state import services
 
-# NOTE: this module currently only implements discord webhooks
-
-__all__ = (
-    "Footer",
-    "Image",
-    "Thumbnail",
-    "Video",
-    "Provider",
-    "Author",
-    "Field",
-    "Embed",
-    "Webhook",
-)
-
 
 class Footer:
     def __init__(self, text: str, **kwargs: Any) -> None:

--- a/app/objects/achievement.py
+++ b/app/objects/achievement.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.objects.score import Score
 
-__all__ = ("Achievement",)
-
 
 class Achievement:
     """A class to represent a single osu! achievement."""

--- a/app/objects/channel.py
+++ b/app/objects/channel.py
@@ -10,8 +10,6 @@ from app.constants.privileges import Privileges
 if TYPE_CHECKING:
     from app.objects.player import Player
 
-__all__ = ("Channel",)
-
 
 class Channel:
     """An osu! chat channel.

--- a/app/objects/clan.py
+++ b/app/objects/clan.py
@@ -11,8 +11,6 @@ from app.repositories import players as players_repo
 if TYPE_CHECKING:
     from app.objects.player import Player
 
-__all__ = ("Clan",)
-
 
 class Clan:
     """A class to represent a single bancho.py clan."""

--- a/app/settings.py
+++ b/app/settings.py
@@ -2,30 +2,16 @@ from __future__ import annotations
 
 import os
 import tomllib
-from datetime import date
 
 from dotenv import load_dotenv
 
 from app.settings_utils import read_bool
 from app.settings_utils import read_list
-from app.settings_utils import support_deprecated_vars
 
 load_dotenv()
 
-APP_HOST = support_deprecated_vars(
-    new_name="APP_HOST",
-    deprecated_name="SERVER_ADDR",
-    until=date(2024, 1, 1),
-)
-APP_PORT = None
-_app_port = support_deprecated_vars(
-    new_name="APP_PORT",
-    deprecated_name="SERVER_PORT",
-    until=date(2024, 1, 1),
-    allow_empty_string=True,
-)
-if _app_port:
-    APP_PORT = int(_app_port)
+APP_HOST = os.environ["APP_HOST"]
+APP_PORT = int(os.environ["APP_PORT"])
 
 DB_HOST = os.environ["DB_HOST"]
 DB_PORT = int(os.environ["DB_PORT"])

--- a/app/utils.py
+++ b/app/utils.py
@@ -234,6 +234,9 @@ def display_startup_dialog() -> None:
                 Ansi.LRED,
             )
 
+    if not has_internet_connectivity():
+        log("No internet connectivity detected", Ansi.LYELLOW)
+
 
 def has_jpeg_headers_and_trailers(data_view: memoryview) -> bool:
     return data_view[:4] == b"\xff\xd8\xff\xe0" and data_view[6:11] == b"JFIF\x00"

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,13 +2,9 @@ from __future__ import annotations
 
 import ctypes
 import inspect
-import io
-import ipaddress
 import os
 import shutil
-import socket
 import sys
-import types
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -22,7 +18,6 @@ import pymysql
 import app.settings
 from app.logging import Ansi
 from app.logging import log
-from app.logging import printc
 
 T = TypeVar("T")
 
@@ -205,14 +200,6 @@ def ensure_directory_structure() -> None:
 
     if not DEFAULT_AVATAR_PATH.exists():
         download_default_avatar(DEFAULT_AVATAR_PATH)
-
-
-def _install_debugging_hooks() -> None:
-    """Change internals to help with debugging & active development."""
-    if DEBUG_HOOKS_PATH.exists():
-        from _testing import runtime  # type: ignore
-
-        runtime.setup()
 
 
 def is_running_as_admin() -> bool:

--- a/app/utils.py
+++ b/app/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import inspect
 import os
+import socket
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -101,6 +102,29 @@ def download_default_avatar(default_avatar_path: Path) -> None:
 
     log("Downloaded default avatar.", Ansi.LGREEN)
     default_avatar_path.write_bytes(resp.content)
+
+
+def has_internet_connectivity(timeout: float = 1.0) -> bool:
+    """Check for an active internet connection."""
+    COMMON_DNS_SERVERS = (
+        # Cloudflare
+        "1.1.1.1",
+        "1.0.0.1",
+        # Google
+        "8.8.8.8",
+        "8.8.4.4",
+    )
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        for addr in COMMON_DNS_SERVERS:
+            try:
+                sock.connect((addr, 53))
+                return True
+            except OSError:
+                continue
+
+    # all connections failed
+    return False
 
 
 class FrameInfo(TypedDict):

--- a/app/utils.py
+++ b/app/utils.py
@@ -114,14 +114,15 @@ def has_internet_connectivity(timeout: float = 1.0) -> bool:
         "8.8.8.8",
         "8.8.4.4",
     )
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(timeout)
-        for addr in COMMON_DNS_SERVERS:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as client:
+        client.settimeout(timeout)
+        for host in COMMON_DNS_SERVERS:
             try:
-                sock.connect((addr, 53))
-                return True
+                client.connect((host, 53))
             except OSError:
                 continue
+            else:
+                return True
 
     # all connections failed
     return False

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -90,9 +90,6 @@ services:
       - SSL_CERT_PATH=${SSL_CERT_PATH}
       - SSL_KEY_PATH=${SSL_KEY_PATH}
       - DEVELOPER_MODE=${DEVELOPER_MODE}
-      # On deprecation path
-      - SERVER_ADDR=${SERVER_ADDR}
-      - SERVER_PORT=${SERVER_PORT}
 
 volumes:
   test-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,9 +86,6 @@ services:
       - SSL_CERT_PATH=${SSL_CERT_PATH}
       - SSL_KEY_PATH=${SSL_KEY_PATH}
       - DEVELOPER_MODE=${DEVELOPER_MODE}
-      # On deprecation path
-      - SERVER_ADDR=${SERVER_ADDR}
-      - SERVER_PORT=${SERVER_PORT}
 
 volumes:
   data:

--- a/ext/Caddyfile
+++ b/ext/Caddyfile
@@ -8,8 +8,6 @@
 
 c.{$DOMAIN}, ce.{$DOMAIN}, c4.{$DOMAIN}, osu.{$DOMAIN}, b.{$DOMAIN}, api.{$DOMAIN} {
 	encode gzip
-	# NOTE: if you wish to use unix sockets,
-	# reverse_proxy * unix//tmp/bancho.sock {
 	reverse_proxy * 127.0.0.1:{$APP_PORT} {
 		header_up X-Real-IP {remote_host}
 	}

--- a/ext/nginx.conf.example
+++ b/ext/nginx.conf.example
@@ -4,8 +4,6 @@
 
 upstream bancho {
     server 127.0.0.1:${APP_PORT};
-    # NOTE: if you wish to use unix sockets,
-    # server unix:/tmp/bancho.sock fail_timeout=0;
 }
 
 server {

--- a/main.py
+++ b/main.py
@@ -1,111 +1,16 @@
 #!/usr/bin/env python3.11
-"""main.py - a user-friendly, safe wrapper around bancho.py's runtime
-
-bancho.py is an in-progress osu! server implementation for developers of all levels
-of experience interested in hosting their own osu private server instance(s).
-
-the project is developed primarily by the Akatsuki (https://akatsuki.pw) team,
-and our aim is to create the most easily maintainable, reliable, and feature-rich
-osu! server implementation available.
-
-we're also fully open source!
-https://github.com/osuAkatsuki/bancho.py
-"""
 from __future__ import annotations
 
-__author__ = "Joshua Smith (cmyui)"
-__email__ = "josh@akatsuki.gg"
-__discord__ = "cmyui#0425"
-
-import os
-
-# set working directory to the bancho/ directory.
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-
-import argparse
 import logging
-import sys
-from collections.abc import Sequence
 
 import uvicorn
 
 import app.settings
 import app.utils
-from app.logging import Ansi
-from app.logging import log
 
 
-def main(argv: Sequence[str]) -> int:
-    """Ensure runtime environment is ready, and start the server."""
-
-    parser = argparse.ArgumentParser(
-        description=("An open-source osu! server implementation by Akatsuki."),
-    )
-    parser.add_argument(
-        "-V",
-        "--version",
-        action="version",
-        version=f"%(prog)s v{app.settings.VERSION}",
-    )
-
-    parser.parse_args(argv)
-
-    """ Server should be safe to start """
-
-    # install any debugging hooks from
-    # _testing/runtime.py, if present
-    app.utils._install_debugging_hooks()
-
-    # check our internet connection status
-    if not app.utils.check_connection(timeout=1.5):
-        log("No internet connection available.", Ansi.LYELLOW)
-
-    # show info & any contextual warnings.
+def main() -> int:
     app.utils.display_startup_dialog()
-
-    # the server supports both inet and unix sockets.
-
-    uds = None
-    host = None
-    port = None
-
-    if (
-        app.utils.is_valid_inet_address(app.settings.APP_HOST)
-        and app.settings.APP_PORT is not None
-    ):
-        host = app.settings.APP_HOST
-        port = app.settings.APP_PORT
-    elif (
-        app.utils.is_valid_unix_address(app.settings.APP_HOST)
-        and app.settings.APP_PORT is None
-    ):
-        uds = app.settings.APP_HOST
-
-        # make sure the socket file does not exist on disk and can be bound
-        # (uvicorn currently does not do this for us, and will raise an exc)
-        if os.path.exists(app.settings.APP_HOST):
-            try:
-                if (
-                    app.utils.processes_listening_on_unix_socket(app.settings.APP_HOST)
-                    != 0
-                ):
-                    log(
-                        f"There are other processes listening on {app.settings.APP_HOST}.\n"
-                        f"If you've lost it, bancho.py can be killed gracefully with SIGINT.",
-                        Ansi.LRED,
-                    )
-                    return 1
-            except Exception:
-                pass
-            else:
-                os.remove(app.settings.APP_HOST)
-    else:
-        raise ValueError(
-            "%r does not appear to be an IPv4, IPv6 or Unix address"
-            % app.settings.APP_HOST,
-        ) from None
-
-    # run the server indefinitely
     uvicorn.run(
         "app.api.init_api:asgi_app",
         reload=app.settings.DEBUG,
@@ -113,13 +18,11 @@ def main(argv: Sequence[str]) -> int:
         server_header=False,
         date_header=False,
         headers=[("bancho-version", app.settings.VERSION)],
-        uds=uds,
-        host=host or "127.0.0.1",  # uvicorn defaults
-        port=port or 8000,  # uvicorn defaults
+        host=app.settings.APP_HOST,
+        port=app.settings.APP_PORT,
     )
-
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    exit(main())

--- a/main.py
+++ b/main.py
@@ -7,10 +7,14 @@ import uvicorn
 
 import app.settings
 import app.utils
+from app.logging import Ansi
+from app.logging import log
 
 
 def main() -> int:
     app.utils.display_startup_dialog()
+    if not app.utils.has_internet_connectivity():
+        log("No internet connectivity detected", Ansi.LYELLOW)
     uvicorn.run(
         "app.api.init_api:asgi_app",
         reload=app.settings.DEBUG,

--- a/main.py
+++ b/main.py
@@ -7,14 +7,10 @@ import uvicorn
 
 import app.settings
 import app.utils
-from app.logging import Ansi
-from app.logging import log
 
 
 def main() -> int:
     app.utils.display_startup_dialog()
-    if not app.utils.has_internet_connectivity():
-        log("No internet connectivity detected", Ansi.LYELLOW)
     uvicorn.run(
         "app.api.init_api:asgi_app",
         reload=app.settings.DEBUG,


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

This PR removes a couple of features:
- Support for unix sockets and related checks
- Insurance that the running python version is (>=3.11)
- Support for deprecated `SERVER_ADDR` and `SERVER_PORT` config vars - now only `APP_x` variants exist
- Exception hooks to catch some cases and display them in more simple light
- Validations to INET addresses
- Debugging hooks under `_testing.runtime`
- CLI handling using argparse for `main.py` (was only used for `./main.py -V`)

All of these seem like unnecessary complexity requiring extra maintenance overhead with low value delivered.

It also migrates more direct queries to SQL to instead use `players_repo`, removes usage of `__all__` in modules, and more general cleanup.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
