### PR TITLE
fix: docker failing to install cryptography

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ RUN apt update && apt install --no-install-recommends -y \
     git curl build-essential=12.9 \
     && rm -rf /var/lib/apt/lists/*
 
+RUN curl https://sh.rustup.rs | bash -s -- -y
+
 COPY pyproject.toml poetry.lock ./
 RUN pip install -U pip poetry
 RUN poetry config virtualenvs.create false
-RUN poetry install --no-root
+RUN PATH="$HOME/.cargo/bin:$PATH" poetry install --no-root
 
 RUN apt update && \
     apt install -y default-mysql-client redis-tools


### PR DESCRIPTION
# Describe your changes
since cryptography is now in rust, it will fail to install without a rust compiler installed.

## Related Issues / Projects

## Checklist
- [ ] I've manually tested my code
