### PR TITLE
feat: enable building arm64 docker images

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64, linux/arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64, linux/arm64
-          outputs: type=docker,dest=/tmp/docker.tar
+          outputs: type=oci,dest=/tmp/docker.tar
           tags: bancho.py:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64, linux/arm64
           outputs: type=docker,dest=/tmp/docker.tar
           tags: bancho.py:${{ github.sha }}
           cache-from: type=gha
@@ -50,7 +51,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/bancho.py:latest


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

Since we have switched to poetry, we can now enable arm64 docker image builds. Some users have asked for this.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
