### PR TITLE
Replace use of `docker-compose` with `docker compose`.

### DIFF
--- a/.github/docs/wiki/Setting-up.md
+++ b/.github/docs/wiki/Setting-up.md
@@ -10,8 +10,7 @@ git clone https://github.com/osuAkatsuki/bancho.py
 cd bancho.py
 
 # install docker for building the application image
-# install docker-compose for running the application & dependencies
-sudo apt install -y docker docker-compose
+sudo apt install -y docker
 ```
 
 ## configuring bancho.py

--- a/.github/docs/wiki/locale/de-DE/Setting-up-de-DE.md
+++ b/.github/docs/wiki/locale/de-DE/Setting-up-de-DE.md
@@ -10,8 +10,7 @@ git clone https://github.com/osuAkatsuki/bancho.py
 cd bancho.py
 
 # install docker for building the application image
-# install docker-compose for running the application & dependencies
-sudo apt install -y docker docker-compose
+sudo apt install -y docker
 ```
 
 ## configuring bancho.py

--- a/.github/docs/wiki/locale/zh-CN/Setting-up-zh-CN.md
+++ b/.github/docs/wiki/locale/zh-CN/Setting-up-zh-CN.md
@@ -10,8 +10,7 @@ git clone https://github.com/osuAkatsuki/bancho.py
 cd bancho.py
 
 # install docker for building the application image
-# install docker-compose for running the application & dependencies
-sudo apt install -y docker docker-compose
+sudo apt install -y docker
 ```
 
 ## configuring bancho.py

--- a/Makefile
+++ b/Makefile
@@ -5,24 +5,24 @@ build:
 	docker build -t bancho:latest .
 
 run:
-	docker-compose up bancho mysql redis
+	docker compose up bancho mysql redis
 
 run-bg:
-	docker-compose up -d bancho mysql redis
+	docker compose up -d bancho mysql redis
 
 run-caddy:
 	caddy run --envfile .env --config ext/Caddyfile
 
 last?=1
 logs:
-	docker-compose logs -f bancho mysql redis --tail ${last}
+	docker compose logs -f bancho mysql redis --tail ${last}
 
 shell:
 	poetry shell
 
 test:
-	docker-compose -f docker-compose.test.yml up -d bancho-test mysql-test redis-test
-	docker-compose -f docker-compose.test.yml exec -T bancho-test /srv/root/scripts/run-tests.sh
+	docker compose -f docker-compose.test.yml up -d bancho-test mysql-test redis-test
+	docker compose -f docker-compose.test.yml exec -T bancho-test /srv/root/scripts/run-tests.sh
 
 lint:
 	poetry run pre-commit run --all-files

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ## shared services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   ## shared services
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
The use of `docker-compose` has been officially deprecated in favour of `docker compose` (part of the official Docker package). On newer distros, `docker-compose` no longer works.

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
