### PR TITLE
Ignore warnings from multipart.multipart logger to fix mass log spam

### DIFF
--- a/logging.yaml.example
+++ b/logging.yaml.example
@@ -9,6 +9,10 @@ loggers:
     level: WARNING
     handlers: [console]
     propagate: no
+  multipart.multipart:
+    level: ERROR
+    handlers: [console]
+    propagate: no
 handlers:
   console:
     class: logging.StreamHandler


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

Fixes this:

<img width="775" alt="image" src="https://github.com/user-attachments/assets/24cb3d61-4b2b-436e-925d-9c5b354e2c88">


## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
