### PR TITLE
feat: add offline functionality for !recent command

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -62,6 +62,7 @@ from app.repositories import map_requests as map_requests_repo
 from app.repositories import maps as maps_repo
 from app.repositories import tourney_pool_maps as tourney_pool_maps_repo
 from app.repositories import tourney_pools as tourney_pools_repo
+from app.repositories import scores as scores_repo
 from app.repositories import users as users_repo
 from app.usecases.performance import ScoreParams
 
@@ -314,36 +315,36 @@ async def maplink(ctx: Context) -> str | None:
 async def recent(ctx: Context) -> str | None:
     """Show information about a player's most recent score."""
     if ctx.args:
-        target = app.state.sessions.players.get(name=" ".join(ctx.args))
+        target = await users_repo.fetch_one(name=ctx.args[1])
         if not target:
             return "Player not found."
+        score = await scores_repo.fetch_recent(user_id=target["id"])
     else:
-        target = ctx.player
-
-    score = target.recent_score
+        score = await scores_repo.fetch_recent(user_id=ctx.player.id)
     if not score:
-        return "No scores found (only saves per play session)."
+        return "No scores found."
 
-    if score.bmap is None:
+    beatmap = await Beatmap.from_md5(score["map_md5"])
+    if beatmap is None:
         return "We don't have a beatmap on file for your recent score."
 
-    l = [f"[{score.mode!r}] {score.bmap.embed}", f"{score.acc:.2f}%"]
+    l = [f"[{score['mode']!r}] {beatmap.embed}", f"{score['acc']:.2f}%"]
 
-    if score.mods:
-        l.insert(1, f"+{score.mods!r}")
+    if score["mods"]:
+        l.insert(1, f"+{score['mods']!r}")
 
     l = [" ".join(l)]
 
-    if score.passed:
-        rank = score.rank if score.status == SubmissionStatus.BEST else "NA"
-        l.append(f"PASS {{{score.pp:.2f}pp #{rank}}}")
+    if score["grade"] != "F":
+        rank = score["grade"] if score["status"] == SubmissionStatus.BEST else "NA"
+        l.append(f"PASS {{{score['pp']:.2f}pp #{rank}}}")
     else:
         # XXX: prior to v3.2.0, bancho.py didn't parse total_length from
         # the osu!api, and thus this can do some zerodivision moments.
         # this can probably be removed in the future, or better yet
         # replaced with a better system to fix the maps.
-        if score.bmap.total_length != 0:
-            completion = score.time_elapsed / (score.bmap.total_length * 1000)
+        if beatmap.total_length != 0:
+            completion = score["time_elapsed"] / (beatmap.total_length * 1000)
             l.append(f"FAIL {{{completion * 100:.2f}% complete}})")
         else:
             l.append("FAIL")

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -172,6 +172,17 @@ async def fetch_one(id: int) -> Score | None:
     return cast(Score | None, _score)
 
 
+async def fetch_recent(user_id: int) -> Score | None:
+    select_stmt = (
+        select(*READ_PARAMS)
+        .where(ScoresTable.userid == user_id)
+        .order_by(ScoresTable.id.desc())
+        .limit(1)
+    )
+    _score = await app.state.services.database.fetch_one(select_stmt)
+    return cast(Score | None, _score)
+
+
 async def fetch_count(
     map_md5: str | None = None,
     mods: int | None = None,


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
Replaced session player object with score database object to access recent scores for offline players
## Related Issues / Projects
https://github.com/osuAkatsuki/bancho.py/issues/638
## Checklist
- [ ] I've manually tested my code
