### PR TITLE
feat: add subcommand support

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -180,7 +180,7 @@ mp_commands = CommandSet("mp", "Multiplayer commands.")
 pool_commands = CommandSet("pool", "Mappool commands.")
 clan_commands = CommandSet("clan", "Clan commands.")
 
-regular_commands = []
+regular_commands: list[Command] = []
 command_sets = [
     mp_commands,
     pool_commands,
@@ -2536,6 +2536,8 @@ async def process_commands(
 
     # case-insensitive triggers
     trigger = trigger.lower()
+
+    commands: Sequence[CommandSet | Command]
 
     # check if any command sets match.
     for cmd_set in command_sets:


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
- add subcommand supports.
- backwards compatible with old commands.
- provided command-pretty-print util.

## Related Issues / Projects
usage in production:
https://github.com/ppy-sb/bancho.py/blob/akat-0302-rebased-remove-query-builder/app/sb/streamer_commands.py

```python
# top level command
streamer_commands = CommandSet("streamer", "Streamer commands.")

# register sub command
streamer_list_commands = streamer_commands.subcommand(
    CommandSet(
        "list", # subcommand keyword, "!streamer list" in this case
        "manage streamer list.",
    )
)

# register handlers like normal
@streamer_commands.add(Privileges.VERIFIED, aliases=["", "h"])
async def streamer_help(ctx: Context) -> str | None:
    """Show this message."""

    # provided help_pure will pretty-print commands as well as sub commands,
    # I'm open for better naming
    return help_pure(
        ctx,
        [*streamer_commands.commands, *streamer_commands.subcommands],
        app.settings.COMMAND_PREFIX + "streamer",
    )

# register subcommands
@streamer_list_commands.add(Privileges.DEVELOPER, aliases=["", "h"])
@streamer_list_commands.add(Privileges.MODERATOR, aliases=["", "h"])
@streamer_list_commands.add(Privileges.ADMINISTRATOR, aliases=["", "h"])
async def streamer_list_help(ctx: Context) -> str | None:
    """Show this message."""
    return help_pure(
        ctx,
        [*streamer_list_commands.commands, *streamer_list_commands.subcommands],
        app.settings.COMMAND_PREFIX + "streamer list",
    )

```

both commands can now be used in-game:
```
2024-12-11 10:49 arily: !streamer
2024-12-11 10:49 ChinoBot: !streamer help: Show this message.
!streamer list: manage streamer list.
2024-12-11 10:49 arily: !streamer list
2024-12-11 10:49 ChinoBot: !streamer list help: Show this message.
```

## Checklist
- [x] I've manually tested my code
