### PR TITLE
fix: fix v2 ngeki field in models

### DIFF
--- a/app/api/v2/models/scores.py
+++ b/app/api/v2/models/scores.py
@@ -25,6 +25,7 @@ class Score(BaseModel):
     n100: int
     n50: int
     nmiss: int
+    ngeki: int
     nkatu: int
 
     grade: str


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

Fix v2 ngeki field was lost in v2 scores models

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
