### PR TITLE
feat: lowercase clantags by default

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -2311,7 +2311,7 @@ async def clan_create(ctx: Context) -> str | None:
     if await clans_repo.fetch_one(tag=tag):
         return "That tag has already been claimed by another clan."
 
-    if await clans_repo.fetch_one(tag=tag).upper():
+    if await clans_repo.fetch_one(tag=tag) == tag.upper():
         return "That tag has already been claimed by another clan."
 
     # add clan to sql

--- a/app/commands.py
+++ b/app/commands.py
@@ -2291,7 +2291,7 @@ async def clan_create(ctx: Context) -> str | None:
     if len(ctx.args) < 2:
         return "Invalid syntax: !clan create <tag> <name>"
 
-    tag = ctx.args[0].upper()
+    tag = ctx.args[0]
     if not 1 <= len(tag) <= 6:
         return "Clan tag may be 1-6 characters long."
 
@@ -2308,7 +2308,7 @@ async def clan_create(ctx: Context) -> str | None:
     if await clans_repo.fetch_one(name=name):
         return "That name has already been claimed by another clan."
 
-    if await clans_repo.fetch_one(tag=tag):
+    if await clans_repo.fetch_one(tag=tag) and clans_repo.fetch_one(tag=tag).upper():
         return "That tag has already been claimed by another clan."
 
     # add clan to sql

--- a/app/commands.py
+++ b/app/commands.py
@@ -2308,7 +2308,10 @@ async def clan_create(ctx: Context) -> str | None:
     if await clans_repo.fetch_one(name=name):
         return "That name has already been claimed by another clan."
 
-    if await clans_repo.fetch_one(tag=tag) and clans_repo.fetch_one(tag=tag).upper():
+    if await clans_repo.fetch_one(tag=tag):
+        return "That tag has already been claimed by another clan."
+
+    if await clans_repo.fetch_one(tag=tag).upper():
         return "That tag has already been claimed by another clan."
 
     # add clan to sql


### PR DESCRIPTION
a little QoL change for people that'd like to use it by default

<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
Added a small change in the `!clan create` command to have lowercase clantags by default

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
