### PR TITLE
fix: tourney stream handling in get_allowed_client_versions

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -728,17 +728,16 @@ async def handle_osu_login_request(
             ),
         }
 
-    if osu_version.stream is OsuStream.TOURNEY and not (
-        user_info["priv"] & Privileges.DONATOR
-        and user_info["priv"] & Privileges.UNRESTRICTED
-    ):
-        # trying to use tourney client with insufficient privileges.
-        return {
-            "osu_token": "no",
-            "response_body": app.packets.login_reply(
-                LoginFailureReason.AUTHENTICATION_FAILED,
-            ),
-        }
+    if osu_version.stream is OsuStream.TOURNEY:
+        allowed_priv = Privileges.DONATOR | Privileges.TOURNEY_MANAGER | Privileges.UNRESTRICTED
+        if user_info["priv"] & allowed_priv <= Privileges.UNRESTRICTED:
+            # trying to use tourney client with insufficient privileges.
+            return {
+                "osu_token": "no",
+                "response_body": app.packets.login_reply(
+                    LoginFailureReason.AUTHENTICATION_FAILED,
+                ),
+            }
 
     """ login credentials verified """
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes

tourney client can't connect to bancho due to old clients, as https://osu.ppy.sh/api/v2/changelog?stream=tourney has an empty builds list.

in fact, tourney client use the same channel as the its base osu stream(stable).

## Related Issues / Projects

## Checklist
- [x] I've manually tested my code
