### PR TITLE
Add redis environment: REDIS_PASS

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -32,6 +32,8 @@ services:
       - test-redis-data:/data
     networks:
       - test-network
+    environment:
+      - REDIS_PASS=${REDIS_PASS}
     command:
       - sh
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     user: root
     volumes:
       - redis-data:/data
+    environment:
+      - REDIS_PASS=${REDIS_PASS}
     command:
       - sh
       - -c


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
In the docker-compose.yml file, the Redis section does not have an environment: entry, so the environment variables set in the .env file are not passed into the Docker container. I suspect this is why the redis-server always runs without a password.

I’m not very familiar with using Docker, so I asked ChatGPT, and the response was that the environment: entry is necessary for the password to be applied.

The YouTube link below shows videos I recorded myself using redis-cli.exe to connect.
https://youtu.be/72fQFjOm_I8
The first demonstration shows connecting when the environment: option is missing.
The second demonstration shows connecting when the option is present.
The third demonstration shows attempting to connect again when the option is missing.

## Related Issues / Projects

## Checklist
- [X] I've manually tested my code
