### PR TITLE
check user in a match before allowing match creation

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -1395,18 +1395,7 @@ class MatchCreate(BasePacket):
 
         if player.match:
             player.enqueue(app.packets.match_join_fail())
-            player.send_bot("You're already in a match. We will try removing you from it.")
-
-            async def next_tick():
-                player.leave_match()
-                player.enqueue(
-                    app.packets.notification(
-                        "You can try again. Please report to staff if you keep getting this error."
-                    )
-                )
-
-            asyncio.create_task(next_tick(), name="remove-duplicated-user")
-            return
+            player.leave_match()
 
         # create the channel and add it
         # to the global channel list as

--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -1393,6 +1393,21 @@ class MatchCreate(BasePacket):
             player.enqueue(app.packets.match_join_fail())
             return
 
+        if player.match:
+            player.enqueue(app.packets.match_join_fail())
+            player.send_bot("You're already in a match. We will try removing you from it.")
+
+            async def next_tick():
+                player.leave_match()
+                player.enqueue(
+                    app.packets.notification(
+                        "You can try again. Please report to staff if you keep getting this error."
+                    )
+                )
+
+            asyncio.create_task(next_tick(), name="remove-duplicated-user")
+            return
+
         # create the channel and add it
         # to the global channel list as
         # an instanced channel.

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -635,7 +635,7 @@ class Player:
 
         slot = self.match.get_slot(self)
         if slot is None:
-            log(f"{self} tried leaving a match without its slot?", Ansi.LYELLOW)
+            log(f"{self} tried leaving a match, but slot couldn't be found?", Ansi.LYELLOW)
         else:
             if slot.status == SlotStatus.locked:
                 # player was kicked, keep the slot locked.

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -572,9 +572,29 @@ class Player:
 
         log(f"Unsilenced {self}.", Ansi.LCYAN)
 
+    def _special_case_disconnected_rejoin(self, match: Match, passwd: str) -> bool:
+        """This method will allow user to rejoin a match they were disconnected from. If everything's working properly, this method should never be called."""
+        
+        reverse_slot_search = match.get_slot(self)
+        lobby = app.state.sessions.channels.get_by_name("#lobby")
+        if reverse_slot_search is None:
+            # recoverable, reset user state before perform normal join.
+            self.match = None
+            self.leave_channel(match.chat)
+            self.join_channel(lobby) if lobby else None
+            return self.join_match(match, passwd)
+
+        # user is in the match, but was disconnected.
+        self.join_channel(match.chat)
+        self.leave_channel(lobby) if lobby else None
+        self.enqueue(app.packets.match_join_success(match))
+        return True
+
     def join_match(self, match: Match, passwd: str) -> bool:
         """Attempt to add `self` to `match`."""
         if self.match:
+            if (self.match.id == match.id):
+                return self._special_case_disconnected_rejoin(match, passwd)
             log(f"{self} tried to join multiple matches?")
             self.enqueue(app.packets.match_join_fail())
             return False

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -574,7 +574,7 @@ class Player:
 
     def _special_case_disconnected_rejoin(self, match: Match, passwd: str) -> bool:
         """This method will allow user to rejoin a match they were disconnected from. If everything's working properly, this method should never be called."""
-        
+
         reverse_slot_search = match.get_slot(self)
         lobby = app.state.sessions.channels.get_by_name("#lobby")
         if reverse_slot_search is None:
@@ -593,7 +593,7 @@ class Player:
     def join_match(self, match: Match, passwd: str) -> bool:
         """Attempt to add `self` to `match`."""
         if self.match:
-            if (self.match.id == match.id):
+            if self.match.id == match.id:
                 return self._special_case_disconnected_rejoin(match, passwd)
             log(f"{self} tried to join multiple matches?")
             self.enqueue(app.packets.match_join_fail())
@@ -655,7 +655,10 @@ class Player:
 
         slot = self.match.get_slot(self)
         if slot is None:
-            log(f"{self} tried leaving a match, but slot couldn't be found?", Ansi.LYELLOW)
+            log(
+                f"{self} tried leaving a match, but slot couldn't be found?",
+                Ansi.LYELLOW,
+            )
         else:
             if slot.status == SlotStatus.locked:
                 # player was kicked, keep the slot locked.

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -634,16 +634,17 @@ class Player:
             return
 
         slot = self.match.get_slot(self)
-        assert slot is not None
-
-        if slot.status == SlotStatus.locked:
-            # player was kicked, keep the slot locked.
-            new_status = SlotStatus.locked
+        if slot is None:
+            log(f"{self} tried leaving a match without its slot?", Ansi.LYELLOW)
         else:
-            # player left, open the slot for new players to join.
-            new_status = SlotStatus.open
+            if slot.status == SlotStatus.locked:
+                # player was kicked, keep the slot locked.
+                new_status = SlotStatus.locked
+            else:
+                # player left, open the slot for new players to join.
+                new_status = SlotStatus.open
 
-        slot.reset(new_status=new_status)
+            slot.reset(new_status=new_status)
 
         self.leave_channel(self.match.chat)
 


### PR DESCRIPTION
<!--
    - Thank you for contributing to bancho.py!
    - Titles should follow [semantic commit message format](https://sparkbox.com/foundry/semantic_commit_messages)
-->

# Describe your changes
check user in a match before allowing match creation

## Related Issues / Projects
<img width="992" height="129" alt="image" src="https://github.com/user-attachments/assets/689eb63b-1185-48cf-9a84-19b251147e68" />
We occasionally have 2 rooms with same host.
for some reason the leave match packet wasn't received or sent.

## Checklist
- [] I've manually tested my code
(still collecting data in our prod)