### PR TITLE
Cache presence/stats packet serialization

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -291,9 +291,11 @@ class ChangeAction(BasePacket):
         player.status.mode = GameMode(self.mode)
         player.status.map_id = self.map_id
 
+        player.invalidate_cached_stats()
+
         # broadcast it to all online players.
         if not player.restricted:
-            app.state.sessions.players.enqueue(app.packets.user_stats(player))
+            app.state.sessions.players.enqueue(player.cached_stats)
 
 
 IGNORED_CHANNELS: list[str] = ["#highlight", "#userlog"]
@@ -920,7 +922,7 @@ async def handle_osu_login_request(
     data += app.packets.silence_end(player.remaining_silence)
 
     # update our new player's stats, and broadcast them.
-    user_data = app.packets.user_presence(player) + app.packets.user_stats(player)
+    user_data = player.cached_presence + player.cached_stats
 
     data += user_data
 
@@ -938,8 +940,8 @@ async def handle_osu_login_request(
                     data += app.packets.bot_presence(o)
                     data += app.packets.bot_stats(o)
                 else:
-                    data += app.packets.user_presence(o)
-                    data += app.packets.user_stats(o)
+                    data += o.cached_presence
+                    data += o.cached_stats
 
         # the player may have been sent mail while offline,
         # enqueue any messages from their respective authors.

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -668,7 +668,8 @@ async def osuSubmitModularSelector(
         score.player.status.mode = score.mode
 
         if not score.player.restricted:
-            app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
+            score.player.invalidate_cached_stats()
+            app.state.sessions.players.enqueue(score.player.cached_stats)
 
     # hold a lock around (check if submitted, submission) to ensure no duplicates
     # are submitted to the database, and potentially award duplicate score/pp/etc.
@@ -949,7 +950,8 @@ async def osuSubmitModularSelector(
 
     if not score.player.restricted:
         # enqueue new stats info to all other users
-        app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
+        score.player.invalidate_cached_stats()
+        app.state.sessions.players.enqueue(score.player.cached_stats)
 
         # update beatmap with new stats
         score.bmap.plays += 1

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -289,6 +289,9 @@ class Player:
 
         self._packet_queue: list[bytes] = []
 
+        self._cached_presence: bytes | None = None
+        self._cached_stats: bytes | None = None
+
     def __repr__(self) -> str:
         return f"<{self.name} ({self.id})>"
 
@@ -412,6 +415,8 @@ class Player:
         if "bancho_priv" in vars(self):
             del self.bancho_priv  # wipe cached_property
 
+        self.invalidate_cached_presence()
+
         await users_repo.partial_update(
             id=self.id,
             priv=self.priv,
@@ -423,6 +428,8 @@ class Player:
         self.priv |= bits
         if "bancho_priv" in vars(self):
             del self.bancho_priv  # wipe cached_property
+
+        self.invalidate_cached_presence()
 
         await users_repo.partial_update(
             id=self.id,
@@ -440,6 +447,8 @@ class Player:
         self.priv &= ~bits
         if "bancho_priv" in vars(self):
             del self.bancho_priv  # wipe cached_property
+
+        self.invalidate_cached_presence()
 
         await users_repo.partial_update(
             id=self.id,
@@ -971,6 +980,9 @@ class Player:
                 },
             )
 
+        self.invalidate_cached_presence()
+        self.invalidate_cached_stats()
+
     def update_latest_activity_soon(self) -> None:
         """Update the player's latest activity in the database."""
         task = users_repo.partial_update(
@@ -991,6 +1003,24 @@ class Player:
             return data
 
         return None
+
+    @property
+    def cached_presence(self) -> bytes:
+        if self._cached_presence is None:
+            self._cached_presence = app.packets.user_presence(self)
+        return self._cached_presence
+
+    @property
+    def cached_stats(self) -> bytes:
+        if self._cached_stats is None:
+            self._cached_stats = app.packets.user_stats(self)
+        return self._cached_stats
+
+    def invalidate_cached_presence(self) -> None:
+        self._cached_presence = None
+
+    def invalidate_cached_stats(self) -> None:
+        self._cached_stats = None
 
     def send(self, msg: str, sender: Player, chan: Channel | None = None) -> None:
         """Enqueue `sender`'s `msg` to `self`. Sent in `chan`, or dm."""


### PR DESCRIPTION
## Summary

- Adds lazy caching of `user_presence` and `user_stats` packet serialization on each `Player` object, avoiding redundant re-serialization when the same player's packets are broadcast to many recipients
- Cached bytes are invalidated when underlying data changes: privilege updates (`update_privs`, `add_privs`, `remove_privs`), full stats reload (`stats_from_sql_full`), status changes, and score submissions
- Updates all call sites in `cho.py` (login handler, action change) and `osu.py` (score submission) to use cached packets

## Test plan

- [x] mypy type checking passes (`python -m mypy app/`)
- [ ] Verify login flow sends correct presence/stats to all online players
- [ ] Verify action changes broadcast updated cached stats
- [ ] Verify score submission invalidates and re-broadcasts stats
- [ ] Verify privilege changes invalidate cached presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)