### PR TITLE
perf: replace per-player broadcast copies with shared log

### DIFF
--- a/app/bg_loops.py
+++ b/app/bg_loops.py
@@ -81,6 +81,8 @@ async def _disconnect_ghosts(interval: int) -> None:
                 log(f"Auto-dced {player}.", Ansi.LMAGENTA)
                 player.logout()
 
+        app.state.sessions.players.trim_broadcast_log()
+
 
 async def _update_bot_status(interval: int) -> None:
     """Re roll the bot status, every `interval`."""

--- a/app/objects/collections.py
+++ b/app/objects/collections.py
@@ -124,6 +124,8 @@ class Players(list[Player]):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        self._broadcast_log: list[tuple[bytes, frozenset[int]]] = []
+        self._broadcast_seq: int = 0
 
     def __iter__(self) -> Iterator[Player]:
         return super().__iter__()
@@ -161,9 +163,22 @@ class Players(list[Player]):
 
     def enqueue(self, data: bytes, immune: Sequence[Player] = []) -> None:
         """Enqueue `data` to all players, except for those in `immune`."""
-        for player in self:
-            if player not in immune:
-                player.enqueue(data)
+        immune_ids = frozenset(p.id for p in immune)
+        self._broadcast_log.append((data, immune_ids))
+        self._broadcast_seq += 1
+
+    def trim_broadcast_log(self) -> None:
+        """Remove broadcast log entries that all players have consumed."""
+        if not self:
+            self._broadcast_log.clear()
+            return
+        min_cursor = min(
+            p._broadcast_cursor for p in self
+            if not p.is_bot_client
+        ) if any(not p.is_bot_client for p in self) else self._broadcast_seq
+        trim_count = min_cursor - (self._broadcast_seq - len(self._broadcast_log))
+        if trim_count > 0:
+            del self._broadcast_log[:trim_count]
 
     def get(
         self,
@@ -273,6 +288,7 @@ class Players(list[Player]):
             return
 
         super().append(player)
+        player._broadcast_cursor = self._broadcast_seq
 
     def remove(self, player: Player) -> None:
         """Remove `p` from the list."""

--- a/app/objects/player.py
+++ b/app/objects/player.py
@@ -288,6 +288,7 @@ class Player:
         self.last_np: LastNp | None = None
 
         self._packet_queue = bytearray()
+        self._broadcast_cursor: int = 0
 
     def __repr__(self) -> str:
         return f"<{self.name} ({self.id})>"
@@ -985,11 +986,25 @@ class Player:
 
     def dequeue(self) -> bytes | None:
         """Get data from the queue to send to the client."""
+        parts: list[bytes] = []
+
+        # drain broadcast log entries since our last cursor
+        players = app.state.sessions.players
+        log_start = players._broadcast_seq - len(players._broadcast_log)
+        offset = max(0, self._broadcast_cursor - log_start)
+        for entry_data, immune_ids in players._broadcast_log[offset:]:
+            if self.id not in immune_ids:
+                parts.append(entry_data)
+        self._broadcast_cursor = players._broadcast_seq
+
+        # drain personal packet queue
         if self._packet_queue:
             data = bytes(self._packet_queue)
             self._packet_queue.clear()
-            return data
+            parts.append(data)
 
+        if parts:
+            return b"".join(parts)
         return None
 
     def send(self, msg: str, sender: Player, chan: Channel | None = None) -> None:


### PR DESCRIPTION
## Summary
- Replaces the O(N) per-player copy in `Players.enqueue()` with a single append to a shared broadcast log
- Each player tracks a cursor (`_broadcast_cursor`) and drains new entries on `dequeue()`
- Adds `trim_broadcast_log()` to prune entries that all players have consumed, called periodically from the ghost-disconnect loop

## Motivation
The previous `Players.enqueue()` iterated every online player and copied broadcast data into each player's personal packet queue. With many players online, this created N copies of the same data per broadcast. The new approach appends once to a shared log and lets each player read from it on demand, reducing memory pressure and CPU time for broadcasts.

## Test plan
- [ ] Verify mypy passes (`python -m mypy app/`)
- [ ] Manual test: confirm broadcast packets (e.g. user stats updates, logout notifications) are still received by all online clients
- [ ] Verify immune players (e.g. the sender in chat messages) are correctly excluded from broadcast entries
- [ ] Verify bot client is skipped when computing `min_cursor` in `trim_broadcast_log`
- [ ] Verify new players joining mid-broadcast only receive entries enqueued after they connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)