### PR TITLE
wrap score submission db writes in a transaction

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -768,53 +768,57 @@ async def osuSubmitModularSelector(
                     assert announce_chan is not None
                     announce_chan.send(" ".join(ann), sender=score.player, to_self=True)
 
-            # this score is our best score.
-            # update any preexisting personal best
-            # records with SubmissionStatus.SUBMITTED.
-            await app.state.services.database.execute(
-                "UPDATE scores SET status = 1 "
-                "WHERE status = 2 AND map_md5 = :map_md5 "
-                "AND userid = :user_id AND mode = :mode",
+        # wrap the score insert and personal best demotion in a transaction
+        # so we don't end up with partial writes if something fails mid-way
+        async with app.state.services.database.transaction():
+            if score.status == SubmissionStatus.BEST:
+                # this score is our best score.
+                # update any preexisting personal best
+                # records with SubmissionStatus.SUBMITTED.
+                await app.state.services.database.execute(
+                    "UPDATE scores SET status = 1 "
+                    "WHERE status = 2 AND map_md5 = :map_md5 "
+                    "AND userid = :user_id AND mode = :mode",
+                    {
+                        "map_md5": score.bmap.md5,
+                        "user_id": score.player.id,
+                        "mode": score.mode,
+                    },
+                )
+
+            score.id = await app.state.services.database.execute(
+                "INSERT INTO scores "
+                "VALUES (NULL, "
+                ":map_md5, :score, :pp, :acc, "
+                ":max_combo, :mods, :n300, :n100, "
+                ":n50, :nmiss, :ngeki, :nkatu, "
+                ":grade, :status, :mode, :play_time, "
+                ":time_elapsed, :client_flags, :user_id, :perfect, "
+                ":checksum)",
                 {
                     "map_md5": score.bmap.md5,
-                    "user_id": score.player.id,
+                    "score": score.score,
+                    "pp": score.pp,
+                    "acc": score.acc,
+                    "max_combo": score.max_combo,
+                    "mods": score.mods,
+                    "n300": score.n300,
+                    "n100": score.n100,
+                    "n50": score.n50,
+                    "nmiss": score.nmiss,
+                    "ngeki": score.ngeki,
+                    "nkatu": score.nkatu,
+                    "grade": score.grade.name,
+                    "status": score.status,
                     "mode": score.mode,
+                    "play_time": score.server_time,
+                    "time_elapsed": score.time_elapsed,
+                    "client_flags": score.client_flags,
+                    "user_id": score.player.id,
+                    "perfect": score.perfect,
+                    "checksum": score.client_checksum,
                 },
             )
-
-        score.id = await app.state.services.database.execute(
-            "INSERT INTO scores "
-            "VALUES (NULL, "
-            ":map_md5, :score, :pp, :acc, "
-            ":max_combo, :mods, :n300, :n100, "
-            ":n50, :nmiss, :ngeki, :nkatu, "
-            ":grade, :status, :mode, :play_time, "
-            ":time_elapsed, :client_flags, :user_id, :perfect, "
-            ":checksum)",
-            {
-                "map_md5": score.bmap.md5,
-                "score": score.score,
-                "pp": score.pp,
-                "acc": score.acc,
-                "max_combo": score.max_combo,
-                "mods": score.mods,
-                "n300": score.n300,
-                "n100": score.n100,
-                "n50": score.n50,
-                "nmiss": score.nmiss,
-                "ngeki": score.ngeki,
-                "nkatu": score.nkatu,
-                "grade": score.grade.name,
-                "status": score.status,
-                "mode": score.mode,
-                "play_time": score.server_time,
-                "time_elapsed": score.time_elapsed,
-                "client_flags": score.client_flags,
-                "user_id": score.player.id,
-                "perfect": score.perfect,
-                "checksum": score.client_checksum,
-            },
-        )
 
     if score.passed:
         replay_data = await replay_file.read()


### PR DESCRIPTION
Fixes #758

The personal best demotion and new score insert were two independent DB calls. Wrapped them in a single transaction so they either both commit or neither does — no more silent pb loss if the process dies mid-write.