### PR TITLE
replace assert with explicit check in comment validation

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -1468,9 +1468,8 @@ async def osuComment(
         # client is submitting a new comment
 
         # validate all required params are provided
-        assert target is not None
-        assert start_time is not None
-        assert comment is not None
+        if target is None or start_time is None or comment is None:
+            return Response(b"", status_code=400)
 
         # get the corresponding id from the request
         if target == "song":


### PR DESCRIPTION
Fixes #760

Swapped the bare `assert` statements to a regular conditional that returns 400. Asserts get stripped under `python -O` which would remove these checks entirely.