### PR TITLE
escape user-controlled strings in html debug pages

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import html as html_module
 import re
 import struct
 import time
@@ -15,8 +16,6 @@ from pathlib import Path
 from typing import Literal
 from typing import TypedDict
 from zoneinfo import ZoneInfo
-
-import html as html_module
 
 import bcrypt
 from fastapi import APIRouter

--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -16,6 +16,8 @@ from typing import Literal
 from typing import TypedDict
 from zoneinfo import ZoneInfo
 
+import html as html_module
+
 import bcrypt
 from fastapi import APIRouter
 from fastapi import Response
@@ -134,9 +136,9 @@ async def bancho_view_online_users() -> Response:
 <!DOCTYPE html>
 <body style="font-family: monospace;  white-space: pre-wrap;"><a href="/">back</a>
 users:
-{new_line.join([f"({p.id:>{id_max_length}}): {p.safe_name}" for p in players])}
+{new_line.join([f"({p.id:>{id_max_length}}): {html_module.escape(p.safe_name)}" for p in players])}
 bots:
-{new_line.join(f"({p.id:>{id_max_length}}): {p.safe_name}" for p in bots)}
+{new_line.join(f"({p.id:>{id_max_length}}): {html_module.escape(p.safe_name)}" for p in bots)}
 </body>
 </html>""",
     )
@@ -167,11 +169,11 @@ async def bancho_view_matches() -> Response:
 <body style="font-family: monospace;  white-space: pre-wrap;"><a href="/">back</a>
 matches:
 {new_line.join(
-    f'''{(ON_GOING if m.in_progress else IDLE):<{max_status_length}} ({m.id:>{match_id_max_length}}): {m.name}
+    f'''{(ON_GOING if m.in_progress else IDLE):<{max_status_length}} ({m.id:>{match_id_max_length}}): {html_module.escape(m.name)}
 -- '''
     + f"{new_line}-- ".join([
-        f'{BEATMAP:<{max_properties_length}}: {m.map_name}',
-        f'{HOST:<{max_properties_length}}: <{m.host.id}> {m.host.safe_name}'
+        f'{BEATMAP:<{max_properties_length}}: {html_module.escape(m.map_name)}',
+        f'{HOST:<{max_properties_length}}: <{m.host.id}> {html_module.escape(m.host.safe_name)}'
     ]) for m in matches
 )}
 </body>


### PR DESCRIPTION
Fixes #761

Runs `html.escape()` on player names and match names/map names in the `/`, `/online`, and `/matches` endpoints. Match names are fully user controlled so this was a straightforward XSS.