### PR TITLE
chore: update non-python dependencies

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         name: Checkout
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64, linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64, linux/arm64
@@ -36,20 +36,20 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker
           path: /tmp/docker.tar
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           context: .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install uv
-        run: python -m pip install --upgrade uv==0.8.12 wheel
+        run: python -m pip install --upgrade uv==0.11.23 wheel
       - name: Install dependencies
         run: uv sync --frozen --all-groups --no-install-project
       - name: Run mypy

--- a/.github/workflows/sync-docs.yaml
+++ b/.github/workflows/sync-docs.yaml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Push files into wiki repo
-        uses: newrelic/wiki-sync-action@main
+        uses: newrelic/wiki-sync-action@v1.0.1
         with:
           source: ${{ env.REPO_PATH }}
           destination: ${{ env.WIKI_PATH }}
@@ -40,13 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: master
 
       - name: Push files into repo
-        uses: newrelic/wiki-sync-action@main
+        uses: newrelic/wiki-sync-action@v1.0.1
         with:
           source: ${{ env.WIKI_PATH }}
           destination: ${{ env.REPO_PATH }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build application image
         run: docker build -t bancho:latest .
@@ -35,7 +35,7 @@ jobs:
         run: docker compose --env-file .env.test -f docker-compose.test.yml down --volumes --remove-orphans
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: code-coverage-report
           path: coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml uv.lock ./
-RUN pip install -U pip uv==0.8.12
+RUN pip install -U pip uv==0.11.23
 RUN UV_PROJECT_ENVIRONMENT=/usr/local uv sync --frozen --no-install-project --inexact
 
 FROM python:3.11-slim

--- a/docker-compose.cloudflared.yml
+++ b/docker-compose.cloudflared.yml
@@ -1,6 +1,6 @@
 services:
   cloudflared:
-    image: cloudflare/cloudflared:2025.9.1
+    image: cloudflare/cloudflared:2026.6.1
     restart: unless-stopped
     command: tunnel run
     env_file:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ services:
   ## shared services
 
   mysql-test:
-    image: mysql:9.4.0
+    image: mysql:9.7.1
     # ports:
     #   - ${DB_PORT}:${DB_PORT}
     environment:
@@ -24,7 +24,7 @@ services:
       retries: 10
 
   redis-test:
-    image: redis:8.2.2
+    image: redis:8.8.0
     # ports:
     #   - ${REDIS_PORT}:${REDIS_PORT}
     user: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ## shared services
 
   mysql:
-    image: mysql:9.4.0
+    image: mysql:9.7.1
     # ports:
     #   - ${DB_PORT}:${DB_PORT}
     environment:
@@ -22,7 +22,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:8.2.2
+    image: redis:8.8.0
     # ports:
     #   - ${REDIS_PORT}:${REDIS_PORT}
     user: root


### PR DESCRIPTION
## Summary
- Bump Docker service images: MySQL 9.7.1, Redis 8.8.0, cloudflared 2026.6.1.
- Bump GitHub Actions to current major versions for checkout, setup-python, upload-artifact, and Docker actions.
- Bump the pinned uv installer version to 0.11.23 and pin wiki sync to the latest release tag instead of `main`.

## Verification
- `docker compose --env-file .env.example -f docker-compose.yml config --quiet`
- `docker compose --env-file .env.example -f docker-compose.cloudflared.yml config --quiet`
- `docker compose --env-file .env.test -f docker-compose.test.yml config --quiet`
- Parsed all `.github/workflows/*.yaml` with PyYAML
- `uv run --frozen pre-commit run --all-files`
- `docker pull mysql:9.7.1 && docker pull redis:8.8.0 && docker pull cloudflare/cloudflared:2026.6.1`
- `docker build --pull -t bancho:latest .`
- `docker run --rm --entrypoint uv bancho:latest --version` -> `uv 0.11.23`
- `make test` (85 passed, 11 xfailed)
- `make utest` (84 passed, 11 xfailed)
- `uv run --frozen mypy .`
