### PR TITLE
test: add API and domain helper coverage

### DIFF
--- a/app/api/domains/cho.py
+++ b/app/api/domains/cho.py
@@ -502,11 +502,12 @@ class LoginData(TypedDict):
 
 def parse_login_data(data: bytes) -> LoginData:
     """Parse data from the body of a login request."""
+    decoded_login_data = data.decode().rstrip("\n")
     (
         username,
         password_md5,
         remainder,
-    ) = data.decode().split("\n", maxsplit=2)
+    ) = decoded_login_data.split("\n", maxsplit=2)
 
     (
         osu_version,

--- a/app/repositories/maps.py
+++ b/app/repositories/maps.py
@@ -178,9 +178,9 @@ async def create(
         hp=hp,
         diff=diff,
     )
-    rec_id = await app.state.services.database.execute(insert_stmt)
+    await app.state.services.database.execute(insert_stmt)
 
-    select_stmt = select(*READ_PARAMS).where(MapsTable.id == rec_id)
+    select_stmt = select(*READ_PARAMS).where(MapsTable.id == id)
     map = await app.state.services.database.fetch_one(select_stmt)
     assert map is not None
     return cast(Map, map)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ warn_requird_dynamic_aliases = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 
 [tool.isort]
 add_imports = ["from __future__ import annotations"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from collections.abc import AsyncIterator
 
 import httpx
 import pytest
+import pytest_asyncio
 import respx
 from asgi_lifespan import LifespanManager
 from asgi_lifespan._types import ASGIApp
@@ -38,7 +39,7 @@ def mock_out_initial_image_downloads(respx_mock: respx.MockRouter) -> None:
     )
 
 
-@pytest.fixture
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
 async def app() -> AsyncIterator[ASGIApp]:
     async with LifespanManager(
         asgi_app,
@@ -48,7 +49,7 @@ async def app() -> AsyncIterator[ASGIApp]:
         yield manager.app
 
 
-@pytest.fixture
+@pytest_asyncio.fixture(loop_scope="session")
 async def http_client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import secrets
+from datetime import datetime
+
+from app.repositories import clans as clans_repo
+from app.repositories import maps as maps_repo
+from app.repositories import scores as scores_repo
+from app.repositories import stats as stats_repo
+from app.repositories import users as users_repo
+
+
+async def create_user(
+    *,
+    country: str = "ca",
+    preferred_mode: int = 0,
+) -> users_repo.User:
+    suffix = secrets.token_hex(4)
+    user = await users_repo.create(
+        name=f"test-{suffix}",
+        email=f"test-{suffix}@akatsuki.pw",
+        pw_bcrypt=b"not-a-real-password-hash",
+        country=country,
+    )
+
+    if preferred_mode:
+        updated_user = await users_repo.partial_update(
+            id=user["id"],
+            preferred_mode=preferred_mode,
+        )
+        assert updated_user is not None
+        user = updated_user
+
+    return user
+
+
+async def create_player_stats(
+    *,
+    player_id: int,
+    mode: int = 0,
+    pp: int = 123,
+    plays: int = 7,
+) -> stats_repo.Stat:
+    await stats_repo.create_all_modes(player_id)
+
+    stat = await stats_repo.partial_update(
+        player_id=player_id,
+        mode=mode,
+        pp=pp,
+        plays=plays,
+        acc=98.76,
+        max_combo=512,
+        total_hits=1234,
+    )
+    assert stat is not None
+    return stat
+
+
+async def create_clan(*, owner_id: int) -> clans_repo.Clan:
+    suffix = secrets.token_hex(3)
+    return await clans_repo.create(
+        name=f"Clan {suffix}",
+        tag=suffix.upper(),
+        owner=owner_id,
+    )
+
+
+async def create_map(
+    *,
+    set_id: int | None = None,
+    mode: int = 0,
+) -> maps_repo.Map:
+    map_id = secrets.randbelow(1_000_000) + 1_000_000
+    if set_id is None:
+        set_id = secrets.randbelow(1_000_000) + 2_000_000
+
+    suffix = secrets.token_hex(4)
+    return await maps_repo.create(
+        id=map_id,
+        server=maps_repo.MapServer.OSU,
+        set_id=set_id,
+        status=2,
+        md5=secrets.token_hex(16),
+        artist=f"Artist {suffix}",
+        title=f"Title {suffix}",
+        version="Insane",
+        creator="test",
+        filename=f"Artist {suffix} - Title {suffix} (test) [Insane].osu",
+        last_update=datetime(2024, 1, 1, 12, 0, 0),
+        total_length=180,
+        max_combo=512,
+        frozen=False,
+        plays=3,
+        passes=2,
+        mode=mode,
+        bpm=180.0,
+        cs=4.0,
+        ar=9.0,
+        od=8.0,
+        hp=6.0,
+        diff=5.25,
+    )
+
+
+async def create_score(
+    *,
+    player_id: int,
+    map_md5: str,
+) -> scores_repo.Score:
+    return await scores_repo.create(
+        map_md5=map_md5,
+        score=987_654,
+        pp=321.45,
+        acc=98.76,
+        max_combo=512,
+        mods=64,
+        n300=500,
+        n100=12,
+        n50=3,
+        nmiss=1,
+        ngeki=100,
+        nkatu=20,
+        grade="S",
+        status=2,
+        mode=0,
+        play_time=datetime(2024, 1, 1, 12, 30, 0),
+        time_elapsed=120_000,
+        client_flags=0,
+        user_id=player_id,
+        perfect=0,
+        online_checksum=secrets.token_hex(16),
+    )

--- a/tests/integration/api/__init__.py
+++ b/tests/integration/api/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/tests/integration/api/v2_test.py
+++ b/tests/integration/api/v2_test.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import secrets
+
+from fastapi import status
+from httpx import AsyncClient
+
+from tests import factories
+
+API_HEADERS = {"Host": "api.cmyui.xyz"}
+
+
+async def test_v2_player_routes_return_seeded_player_and_stats(
+    http_client: AsyncClient,
+) -> None:
+    preferred_mode = secrets.randbelow(1_000_000) + 10_000
+    user = await factories.create_user(preferred_mode=preferred_mode)
+    stat = await factories.create_player_stats(player_id=user["id"], pp=456, plays=9)
+
+    player_response = await http_client.get(
+        f"/v2/players/{user['id']}",
+        headers=API_HEADERS,
+    )
+    assert player_response.status_code == status.HTTP_200_OK
+    assert player_response.json()["data"]["id"] == user["id"]
+
+    players_response = await http_client.get(
+        "/v2/players",
+        headers=API_HEADERS,
+        params={"preferred_mode": preferred_mode, "page_size": 100},
+    )
+    assert players_response.status_code == status.HTTP_200_OK
+    players_body = players_response.json()
+    assert players_body["meta"]["total"] == 1
+    assert players_body["data"][0]["id"] == user["id"]
+
+    stats_response = await http_client.get(
+        f"/v2/players/{user['id']}/stats/{stat['mode']}",
+        headers=API_HEADERS,
+    )
+    assert stats_response.status_code == status.HTTP_200_OK
+    stats_body = stats_response.json()
+    assert stats_body["data"]["pp"] == 456
+    assert stats_body["data"]["plays"] == 9
+
+    all_stats_response = await http_client.get(
+        f"/v2/players/{user['id']}/stats",
+        headers=API_HEADERS,
+    )
+    assert all_stats_response.status_code == status.HTTP_200_OK
+    assert all_stats_response.json()["meta"]["total"] == 8
+
+    offline_status_response = await http_client.get(
+        f"/v2/players/{user['id']}/status",
+        headers=API_HEADERS,
+    )
+    assert offline_status_response.status_code == status.HTTP_404_NOT_FOUND
+    assert offline_status_response.json() == {
+        "status": "error",
+        "error": "Player status not found.",
+    }
+
+
+async def test_v2_player_route_returns_not_found_for_missing_player(
+    http_client: AsyncClient,
+) -> None:
+    response = await http_client.get("/v2/players/999999999", headers=API_HEADERS)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "status": "error",
+        "error": "Player not found.",
+    }
+
+
+async def test_v2_map_routes_return_seeded_map(
+    http_client: AsyncClient,
+) -> None:
+    set_id = secrets.randbelow(1_000_000) + 20_000
+    beatmap = await factories.create_map(set_id=set_id)
+
+    map_response = await http_client.get(
+        f"/v2/maps/{beatmap['id']}",
+        headers=API_HEADERS,
+    )
+    assert map_response.status_code == status.HTTP_200_OK
+    map_body = map_response.json()
+    assert map_body["data"]["id"] == beatmap["id"]
+    assert map_body["data"]["md5"] == beatmap["md5"]
+
+    maps_response = await http_client.get(
+        "/v2/maps",
+        headers=API_HEADERS,
+        params={"set_id": set_id},
+    )
+    assert maps_response.status_code == status.HTTP_200_OK
+    maps_body = maps_response.json()
+    assert maps_body["meta"]["total"] == 1
+    assert maps_body["data"][0]["id"] == beatmap["id"]
+
+
+async def test_v2_map_route_returns_not_found_for_missing_map(
+    http_client: AsyncClient,
+) -> None:
+    response = await http_client.get("/v2/maps/999999999", headers=API_HEADERS)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "status": "error",
+        "error": "Map not found.",
+    }
+
+
+async def test_v2_score_routes_return_seeded_score(
+    http_client: AsyncClient,
+) -> None:
+    user = await factories.create_user()
+    beatmap = await factories.create_map()
+    score = await factories.create_score(
+        player_id=user["id"],
+        map_md5=beatmap["md5"],
+    )
+
+    score_response = await http_client.get(
+        f"/v2/scores/{score['id']}",
+        headers=API_HEADERS,
+    )
+    assert score_response.status_code == status.HTTP_200_OK
+    score_body = score_response.json()
+    assert score_body["data"]["id"] == score["id"]
+    assert score_body["data"]["userid"] == user["id"]
+    assert score_body["data"]["map_md5"] == beatmap["md5"]
+
+    scores_response = await http_client.get(
+        "/v2/scores",
+        headers=API_HEADERS,
+        params={"user_id": user["id"], "map_md5": beatmap["md5"]},
+    )
+    assert scores_response.status_code == status.HTTP_200_OK
+    scores_body = scores_response.json()
+    assert scores_body["meta"]["total"] == 1
+    assert scores_body["data"][0]["id"] == score["id"]
+
+
+async def test_v2_score_route_returns_not_found_for_missing_score(
+    http_client: AsyncClient,
+) -> None:
+    response = await http_client.get("/v2/scores/999999999", headers=API_HEADERS)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "status": "error",
+        "error": "Score not found.",
+    }
+
+
+async def test_v2_clan_routes_return_seeded_clan(
+    http_client: AsyncClient,
+) -> None:
+    owner = await factories.create_user()
+    clan = await factories.create_clan(owner_id=owner["id"])
+
+    clan_response = await http_client.get(
+        f"/v2/clans/{clan['id']}",
+        headers=API_HEADERS,
+    )
+    assert clan_response.status_code == status.HTTP_200_OK
+    clan_body = clan_response.json()
+    assert clan_body["data"]["id"] == clan["id"]
+    assert clan_body["data"]["owner"] == owner["id"]
+
+    clans_response = await http_client.get("/v2/clans", headers=API_HEADERS)
+    assert clans_response.status_code == status.HTTP_200_OK
+    clan_ids = {clan_data["id"] for clan_data in clans_response.json()["data"]}
+    assert clan["id"] in clan_ids
+
+
+async def test_v2_clan_route_returns_not_found_for_missing_clan(
+    http_client: AsyncClient,
+) -> None:
+    response = await http_client.get("/v2/clans/999999999", headers=API_HEADERS)
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.json() == {
+        "status": "error",
+        "error": "Clan not found.",
+    }

--- a/tests/integration/domains/osu_test.py
+++ b/tests/integration/domains/osu_test.py
@@ -11,6 +11,8 @@ from fastapi import status
 from httpx import AsyncClient
 
 from app import encryption
+from app.repositories import scores as scores_repo
+from app.repositories import users as users_repo
 from testing.sample_data import sample_beatmap_data
 
 
@@ -46,6 +48,8 @@ async def test_score_submission(
         },
     )
     assert response.status_code == status.HTTP_200_OK
+    user = await users_repo.fetch_one(name=username)
+    assert user is not None
 
     osu_version = "20230814"
     utc_offset = -5
@@ -237,7 +241,16 @@ async def test_score_submission(
 
     # ASSERT
     assert response.status_code == status.HTTP_200_OK
+    submitted_scores = await scores_repo.fetch_many(user_id=user["id"])
+    assert len(submitted_scores) == 1
+    submitted_score = submitted_scores[0]
+
     assert (
         response.read()
-        == b"beatmapId:315|beatmapSetId:141|beatmapPlaycount:1|beatmapPasscount:1|approvedDate:2014-05-18 15:41:48|\n|chartId:beatmap|chartUrl:https://osu.cmyui.xyz/s/141|chartName:Beatmap Ranking|rankBefore:|rankAfter:1|rankedScoreBefore:|rankedScoreAfter:26810|totalScoreBefore:|totalScoreAfter:26810|maxComboBefore:|maxComboAfter:52|accuracyBefore:|accuracyAfter:81.94|ppBefore:|ppAfter:10.448|onlineScoreId:1|\n|chartId:overall|chartUrl:https://cmyui.xyz/u/3|chartName:Overall Ranking|rankBefore:|rankAfter:1|rankedScoreBefore:|rankedScoreAfter:26810|totalScoreBefore:|totalScoreAfter:26810|maxComboBefore:|maxComboAfter:52|accuracyBefore:|accuracyAfter:81.94|ppBefore:|ppAfter:11|achievements-new:osu-skill-pass-4+Insanity Approaches+You're not twitching, you're just ready./all-intro-hidden+Blindsight+I can see just perfectly"
+        == (
+            "beatmapId:315|beatmapSetId:141|beatmapPlaycount:1|beatmapPasscount:1|approvedDate:2014-05-18 15:41:48|\n"
+            "|chartId:beatmap|chartUrl:https://osu.cmyui.xyz/s/141|chartName:Beatmap Ranking|rankBefore:|rankAfter:1|rankedScoreBefore:|rankedScoreAfter:26810|totalScoreBefore:|totalScoreAfter:26810|maxComboBefore:|maxComboAfter:52|accuracyBefore:|accuracyAfter:81.94|ppBefore:|ppAfter:10.448|"
+            f"onlineScoreId:{submitted_score['id']}|\n"
+            f"|chartId:overall|chartUrl:https://cmyui.xyz/u/{user['id']}|chartName:Overall Ranking|rankBefore:|rankAfter:1|rankedScoreBefore:|rankedScoreAfter:26810|totalScoreBefore:|totalScoreAfter:26810|maxComboBefore:|maxComboAfter:52|accuracyBefore:|accuracyAfter:81.94|ppBefore:|ppAfter:11|achievements-new:osu-skill-pass-4+Insanity Approaches+You're not twitching, you're just ready./all-intro-hidden+Blindsight+I can see just perfectly"
+        ).encode()
     )

--- a/tests/unit/domain_helpers_test.py
+++ b/tests/unit/domain_helpers_test.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import io
+from datetime import date
+
+import pytest
+from starlette.datastructures import FormData
+from starlette.datastructures import UploadFile
+
+from app.api.domains import cho
+from app.api.domains import osu
+from app.commands import ParsingError
+from app.commands import parse__with__command_args
+from app.commands import status_to_id
+from app.constants.mods import Mods
+from app.objects.player import OsuStream
+from app.packets import MultiplayerMatch
+
+
+def test_parse_login_data_handles_protocol_trailing_newline() -> None:
+    login_data = (
+        b"cmyui\n"
+        b"password-md5\n"
+        b"b20230814.2cuttingedge|-5|1|"
+        b"osu-path.adapt:1.2.3.:adapters:uninstall:disk:|1\n"
+    )
+
+    parsed = cho.parse_login_data(login_data)
+
+    assert parsed == {
+        "username": "cmyui",
+        "password_md5": b"password-md5",
+        "osu_version": "b20230814.2cuttingedge",
+        "utc_offset": -5,
+        "display_city": True,
+        "pm_private": True,
+        "osu_path_md5": "osu-path.adapt",
+        "adapters_str": "1.2.3.",
+        "adapters_md5": "adapters",
+        "uninstall_md5": "uninstall",
+        "disk_signature_md5": "disk",
+    }
+
+
+@pytest.mark.parametrize(
+    ("raw_version", "expected_date", "expected_revision", "expected_stream"),
+    [
+        ("b20230814", date(2023, 8, 14), None, OsuStream.STABLE),
+        ("b20230814.2cuttingedge", date(2023, 8, 14), 2, OsuStream.CUTTINGEDGE),
+        ("b20230814beta", date(2023, 8, 14), None, OsuStream.BETA),
+    ],
+)
+def test_parse_osu_version_string(
+    raw_version: str,
+    expected_date: date,
+    expected_revision: int | None,
+    expected_stream: OsuStream,
+) -> None:
+    parsed = cho.parse_osu_version_string(raw_version)
+
+    assert parsed is not None
+    assert parsed.date == expected_date
+    assert parsed.revision == expected_revision
+    assert parsed.stream is expected_stream
+
+
+def test_parse_osu_version_string_rejects_invalid_versions() -> None:
+    assert cho.parse_osu_version_string("definitely-not-osu") is None
+
+
+def test_parse_adapters_string() -> None:
+    adapters, running_under_wine = cho.parse_adapters_string("1.2.3.")
+
+    assert adapters == ["1", "2", "3"]
+    assert running_under_wine is False
+
+
+def test_parse_adapters_string_detects_wine() -> None:
+    _, running_under_wine = cho.parse_adapters_string("runningunderwine")
+
+    assert running_under_wine is True
+
+
+def test_validate_match_data_accepts_expected_host_and_reasonable_name() -> None:
+    match_data = MultiplayerMatch()
+    match_data.host_id = 32
+    match_data.name = "friendly lobby"
+
+    assert cho.validate_match_data(match_data, expected_host_id=32) is True
+
+
+@pytest.mark.parametrize(
+    ("host_id", "name", "expected_host_id"),
+    [
+        (99, "friendly lobby", 32),
+        (32, "x" * (cho.MAX_MATCH_NAME_LENGTH + 1), 32),
+    ],
+)
+def test_validate_match_data_rejects_untrusted_fields(
+    host_id: int,
+    name: str,
+    expected_host_id: int,
+) -> None:
+    match_data = MultiplayerMatch()
+    match_data.host_id = host_id
+    match_data.name = name
+
+    assert cho.validate_match_data(match_data, expected_host_id) is False
+
+
+def test_parse_score_form_data_returns_score_bytes_and_replay_file() -> None:
+    replay_file = UploadFile(filename="score.osr", file=io.BytesIO(b"replay"))
+    form_data = FormData(
+        [
+            ("score", "encrypted-score"),
+            ("score", replay_file),
+        ],
+    )
+
+    parsed = osu.parse_form_data_score_params(form_data)
+
+    assert parsed == (b"encrypted-score", replay_file)
+
+
+@pytest.mark.parametrize(
+    "form_data",
+    [
+        FormData([("score", "encrypted-score")]),
+        FormData(
+            [
+                ("score", "encrypted-score"),
+                ("score", "not-a-file"),
+            ],
+        ),
+    ],
+)
+def test_parse_score_form_data_rejects_invalid_score_parts(
+    form_data: FormData,
+) -> None:
+    assert osu.parse_form_data_score_params(form_data) is None
+
+
+def test_osu_chart_entry_formats_optional_before_and_after_values() -> None:
+    assert osu.chart_entry("rankedScore", None, 123.45) == (
+        "rankedScoreBefore:|rankedScoreAfter:123.45"
+    )
+
+
+def test_osu_achievement_string_uses_client_delimiters() -> None:
+    assert (
+        osu.format_achievement_string(
+            "osu-combo-500",
+            "500 Combo",
+            "Achieve a 500 combo.",
+        )
+        == "osu-combo-500+500 Combo+Achieve a 500 combo."
+    )
+
+
+def test_with_command_arg_parser_accepts_acc_misses_combo_and_mods() -> None:
+    parsed = parse__with__command_args(0, ["95.5%", "1m", "429x", "+hddt"])
+
+    assert parsed == {
+        "acc": 95.5,
+        "mods": Mods.HIDDEN | Mods.DOUBLETIME,
+        "combo": 429,
+        "nmiss": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_error"),
+    [
+        ([], "Invalid syntax: !with <acc/nmiss/combo/mods ...>"),
+        (["101%"], "Invalid accuracy."),
+        (["bad"], "Unknown argument: bad"),
+    ],
+)
+def test_with_command_arg_parser_rejects_invalid_args(
+    args: list[str],
+    expected_error: str,
+) -> None:
+    parsed = parse__with__command_args(0, args)
+
+    assert isinstance(parsed, ParsingError)
+    assert str(parsed) == expected_error
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_id"),
+    [
+        ("unrank", 0),
+        ("rank", 2),
+        ("love", 5),
+    ],
+)
+def test_status_to_id(status: str, expected_id: int) -> None:
+    assert status_to_id(status) == expected_id


### PR DESCRIPTION
## Summary
- add v2 API integration coverage for players, maps, scores, and clans
- add domain/helper unit coverage for login parsing, osu version parsing, score form parsing, command args, and match validation
- make the ASGI test app/session loop reusable across multiple integration tests
- fix map repository creation lookup and login parsing of protocol bodies with trailing newlines

## Verification
- uv run --frozen --env-file .env.test pytest tests/unit/domain_helpers_test.py -q
- make test
- make lint
- make type-check