### PR TITLE
refactor: extract score submission helpers

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -70,6 +70,7 @@ from app.repositories import stats as stats_repo
 from app.repositories import users as users_repo
 from app.repositories.achievements import Achievement
 from app.usecases import achievements as achievements_usecases
+from app.usecases import score_submission as score_submission_usecase
 from app.usecases import user_achievements as user_achievements_usecases
 from app.utils import escape_enum
 from app.utils import pymysql_encode
@@ -495,14 +496,6 @@ async def osuSearchSetHandler(
     # 0s are threadid, has_vid, has_story, filesize, filesize_novid
 
 
-def chart_entry(name: str, before: float | None, after: float | None) -> str:
-    return f"{name}Before:{before or ''}|{name}After:{after or ''}"
-
-
-def format_achievement_string(file: str, name: str, description: str) -> str:
-    return f"{file}+{name}+{description}"
-
-
 def parse_form_data_score_params(
     score_data: FormData,
 ) -> tuple[bytes, StarletteUploadFile] | None:
@@ -601,45 +594,17 @@ async def osuSubmitModularSelector(
 
     ## perform checksum validation
 
-    unique_id1, unique_id2 = unique_ids.split("|", maxsplit=1)
-    unique_id1_md5 = hashlib.md5(unique_id1.encode()).hexdigest()
-    unique_id2_md5 = hashlib.md5(unique_id2.encode()).hexdigest()
-
     try:
-        assert player.client_details is not None
-
-        if osu_version != f"{player.client_details.osu_version.date:%Y%m%d}":
-            raise ValueError("osu! version mismatch")
-
-        if client_hash_decoded != player.client_details.client_hash:
-            raise ValueError("client hash mismatch")
-        # assert unique ids (c1) are correct and match login params
-        if unique_id1_md5 != player.client_details.uninstall_md5:
-            raise ValueError(
-                f"unique_id1 mismatch ({unique_id1_md5} != {player.client_details.uninstall_md5})",
-            )
-
-        if unique_id2_md5 != player.client_details.disk_signature_md5:
-            raise ValueError(
-                f"unique_id2 mismatch ({unique_id2_md5} != {player.client_details.disk_signature_md5})",
-            )
-
-        # assert online checksums match
-        server_score_checksum = score.compute_online_checksum(
+        score_submission_usecase.validate_submission_integrity(
+            client_details=player.client_details,
             osu_version=osu_version,
-            osu_client_hash=client_hash_decoded,
-            storyboard_checksum=storyboard_md5 or "",
+            client_hash=client_hash_decoded,
+            unique_ids=unique_ids,
+            score=score,
+            storyboard_md5=storyboard_md5,
+            submission_beatmap_md5=bmap_md5,
+            updated_beatmap_hash=updated_beatmap_hash,
         )
-        if score.client_checksum != server_score_checksum:
-            raise ValueError(
-                f"online score checksum mismatch ({server_score_checksum} != {score.client_checksum})",
-            )
-
-        # assert beatmap hashes match
-        if bmap_md5 != updated_beatmap_hash:
-            raise ValueError(
-                f"beatmap hash mismatch ({bmap_md5} != {updated_beatmap_hash})",
-            )
 
     except (ValueError, AssertionError):
         # NOTE: this is undergoing a temporary trial period,
@@ -1001,72 +966,18 @@ async def osuSubmitModularSelector(
                     )
                     unlocked_achievements.append(server_achievement)
 
-            achievements_str = "/".join(
-                format_achievement_string(a["file"], a["name"], a["desc"])
-                for a in unlocked_achievements
-            )
+            achievements = unlocked_achievements
         else:
-            achievements_str = ""
+            achievements = []
 
         # create score submission charts for osu! client to display
-
-        if score.prev_best:
-            beatmap_ranking_chart_entries = (
-                chart_entry("rank", score.prev_best.rank, score.rank),
-                chart_entry("rankedScore", score.prev_best.score, score.score),
-                chart_entry("totalScore", score.prev_best.score, score.score),
-                chart_entry("maxCombo", score.prev_best.max_combo, score.max_combo),
-                chart_entry(
-                    "accuracy",
-                    round(score.prev_best.acc, 2),
-                    round(score.acc, 2),
-                ),
-                chart_entry("pp", score.prev_best.pp, score.pp),
-            )
-        else:
-            # no previous best score
-            beatmap_ranking_chart_entries = (
-                chart_entry("rank", None, score.rank),
-                chart_entry("rankedScore", None, score.score),
-                chart_entry("totalScore", None, score.score),
-                chart_entry("maxCombo", None, score.max_combo),
-                chart_entry("accuracy", None, round(score.acc, 2)),
-                chart_entry("pp", None, score.pp),
-            )
-
-        overall_ranking_chart_entries = (
-            chart_entry("rank", prev_stats.rank, stats.rank),
-            chart_entry("rankedScore", prev_stats.rscore, stats.rscore),
-            chart_entry("totalScore", prev_stats.tscore, stats.tscore),
-            chart_entry("maxCombo", prev_stats.max_combo, stats.max_combo),
-            chart_entry("accuracy", round(prev_stats.acc, 2), round(stats.acc, 2)),
-            chart_entry("pp", prev_stats.pp, stats.pp),
+        response = score_submission_usecase.build_submission_charts(
+            score=score,
+            previous_stats=prev_stats,
+            current_stats=stats,
+            achievements=achievements,
+            domain=app.settings.DOMAIN,
         )
-
-        submission_charts = [
-            # beatmap info chart
-            f"beatmapId:{score.bmap.id}",
-            f"beatmapSetId:{score.bmap.set_id}",
-            f"beatmapPlaycount:{score.bmap.plays}",
-            f"beatmapPasscount:{score.bmap.passes}",
-            f"approvedDate:{score.bmap.last_update}",
-            "\n",
-            # beatmap ranking chart
-            "chartId:beatmap",
-            f"chartUrl:{score.bmap.set.url}",
-            "chartName:Beatmap Ranking",
-            *beatmap_ranking_chart_entries,
-            f"onlineScoreId:{score.id}",
-            "\n",
-            # overall ranking chart
-            "chartId:overall",
-            f"chartUrl:https://{app.settings.DOMAIN}/u/{score.player.id}",
-            "chartName:Overall Ranking",
-            *overall_ranking_chart_entries,
-            f"achievements-new:{achievements_str}",
-        ]
-
-        response = "|".join(submission_charts).encode()
 
     log(
         f"[{score.mode!r}] {score.player} submitted a score! "

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from app.objects.player import ClientDetails
+from app.objects.player import ModeData
+from app.objects.score import Score
+from app.repositories.achievements import Achievement
+
+
+@dataclass(frozen=True)
+class UniqueIdHashes:
+    unique_id1_md5: str
+    unique_id2_md5: str
+
+
+def parse_unique_id_hashes(unique_ids: str) -> UniqueIdHashes:
+    unique_id1, unique_id2 = unique_ids.split("|", maxsplit=1)
+    return UniqueIdHashes(
+        unique_id1_md5=hashlib.md5(unique_id1.encode()).hexdigest(),
+        unique_id2_md5=hashlib.md5(unique_id2.encode()).hexdigest(),
+    )
+
+
+def validate_client_details(
+    *,
+    client_details: ClientDetails | None,
+    osu_version: str,
+    client_hash: str,
+    unique_id_hashes: UniqueIdHashes,
+) -> None:
+    if client_details is None:
+        raise ValueError("missing client details")
+
+    if osu_version != f"{client_details.osu_version.date:%Y%m%d}":
+        raise ValueError("osu! version mismatch")
+
+    if client_hash != client_details.client_hash:
+        raise ValueError("client hash mismatch")
+
+    if unique_id_hashes.unique_id1_md5 != client_details.uninstall_md5:
+        raise ValueError(
+            f"unique_id1 mismatch ({unique_id_hashes.unique_id1_md5} != {client_details.uninstall_md5})",
+        )
+
+    if unique_id_hashes.unique_id2_md5 != client_details.disk_signature_md5:
+        raise ValueError(
+            f"unique_id2 mismatch ({unique_id_hashes.unique_id2_md5} != {client_details.disk_signature_md5})",
+        )
+
+
+def validate_score_checksum(
+    *,
+    score: Score,
+    osu_version: str,
+    client_hash: str,
+    storyboard_md5: str | None,
+) -> None:
+    server_score_checksum = score.compute_online_checksum(
+        osu_version=osu_version,
+        osu_client_hash=client_hash,
+        storyboard_checksum=storyboard_md5 or "",
+    )
+    if score.client_checksum != server_score_checksum:
+        raise ValueError(
+            f"online score checksum mismatch ({server_score_checksum} != {score.client_checksum})",
+        )
+
+
+def validate_beatmap_hash(
+    *,
+    submission_beatmap_md5: str,
+    updated_beatmap_hash: str,
+) -> None:
+    if submission_beatmap_md5 != updated_beatmap_hash:
+        raise ValueError(
+            f"beatmap hash mismatch ({submission_beatmap_md5} != {updated_beatmap_hash})",
+        )
+
+
+def validate_submission_integrity(
+    *,
+    client_details: ClientDetails | None,
+    osu_version: str,
+    client_hash: str,
+    unique_ids: str,
+    score: Score,
+    storyboard_md5: str | None,
+    submission_beatmap_md5: str,
+    updated_beatmap_hash: str,
+) -> None:
+    unique_id_hashes = parse_unique_id_hashes(unique_ids)
+    validate_client_details(
+        client_details=client_details,
+        osu_version=osu_version,
+        client_hash=client_hash,
+        unique_id_hashes=unique_id_hashes,
+    )
+    validate_score_checksum(
+        score=score,
+        osu_version=osu_version,
+        client_hash=client_hash,
+        storyboard_md5=storyboard_md5,
+    )
+    validate_beatmap_hash(
+        submission_beatmap_md5=submission_beatmap_md5,
+        updated_beatmap_hash=updated_beatmap_hash,
+    )
+
+
+def chart_entry(
+    name: str,
+    before: float | int | None,
+    after: float | int | None,
+) -> str:
+    return f"{name}Before:{before or ''}|{name}After:{after or ''}"
+
+
+def format_achievement_string(file: str, name: str, description: str) -> str:
+    return f"{file}+{name}+{description}"
+
+
+def format_achievements(achievements: Sequence[Achievement]) -> str:
+    return "/".join(
+        format_achievement_string(
+            achievement["file"],
+            achievement["name"],
+            achievement["desc"],
+        )
+        for achievement in achievements
+    )
+
+
+def build_submission_charts(
+    *,
+    score: Score,
+    previous_stats: ModeData,
+    current_stats: ModeData,
+    achievements: Sequence[Achievement],
+    domain: str,
+) -> bytes:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    if score.prev_best:
+        beatmap_ranking_chart_entries = (
+            chart_entry("rank", score.prev_best.rank, score.rank),
+            chart_entry("rankedScore", score.prev_best.score, score.score),
+            chart_entry("totalScore", score.prev_best.score, score.score),
+            chart_entry("maxCombo", score.prev_best.max_combo, score.max_combo),
+            chart_entry("accuracy", round(score.prev_best.acc, 2), round(score.acc, 2)),
+            chart_entry("pp", score.prev_best.pp, score.pp),
+        )
+    else:
+        beatmap_ranking_chart_entries = (
+            chart_entry("rank", None, score.rank),
+            chart_entry("rankedScore", None, score.score),
+            chart_entry("totalScore", None, score.score),
+            chart_entry("maxCombo", None, score.max_combo),
+            chart_entry("accuracy", None, round(score.acc, 2)),
+            chart_entry("pp", None, score.pp),
+        )
+
+    overall_ranking_chart_entries = (
+        chart_entry("rank", previous_stats.rank, current_stats.rank),
+        chart_entry("rankedScore", previous_stats.rscore, current_stats.rscore),
+        chart_entry("totalScore", previous_stats.tscore, current_stats.tscore),
+        chart_entry("maxCombo", previous_stats.max_combo, current_stats.max_combo),
+        chart_entry(
+            "accuracy",
+            round(previous_stats.acc, 2),
+            round(current_stats.acc, 2),
+        ),
+        chart_entry("pp", previous_stats.pp, current_stats.pp),
+    )
+
+    submission_charts = [
+        # beatmap info chart
+        f"beatmapId:{score.bmap.id}",
+        f"beatmapSetId:{score.bmap.set_id}",
+        f"beatmapPlaycount:{score.bmap.plays}",
+        f"beatmapPasscount:{score.bmap.passes}",
+        f"approvedDate:{score.bmap.last_update}",
+        "\n",
+        # beatmap ranking chart
+        "chartId:beatmap",
+        f"chartUrl:{score.bmap.set.url}",
+        "chartName:Beatmap Ranking",
+        *beatmap_ranking_chart_entries,
+        f"onlineScoreId:{score.id}",
+        "\n",
+        # overall ranking chart
+        "chartId:overall",
+        f"chartUrl:https://{domain}/u/{score.player.id}",
+        "chartName:Overall Ranking",
+        *overall_ranking_chart_entries,
+        f"achievements-new:{format_achievements(achievements)}",
+    ]
+
+    return "|".join(submission_charts).encode()

--- a/tests/unit/domain_helpers_test.py
+++ b/tests/unit/domain_helpers_test.py
@@ -15,6 +15,7 @@ from app.commands import status_to_id
 from app.constants.mods import Mods
 from app.objects.player import OsuStream
 from app.packets import MultiplayerMatch
+from app.usecases import score_submission as score_submission_usecase
 
 
 def test_parse_login_data_handles_protocol_trailing_newline() -> None:
@@ -140,15 +141,17 @@ def test_parse_score_form_data_rejects_invalid_score_parts(
     assert osu.parse_form_data_score_params(form_data) is None
 
 
-def test_osu_chart_entry_formats_optional_before_and_after_values() -> None:
-    assert osu.chart_entry("rankedScore", None, 123.45) == (
+def test_score_submission_chart_entry_formats_optional_before_and_after_values() -> (
+    None
+):
+    assert score_submission_usecase.chart_entry("rankedScore", None, 123.45) == (
         "rankedScoreBefore:|rankedScoreAfter:123.45"
     )
 
 
-def test_osu_achievement_string_uses_client_delimiters() -> None:
+def test_score_submission_achievement_string_uses_client_delimiters() -> None:
     assert (
-        osu.format_achievement_string(
+        score_submission_usecase.format_achievement_string(
             "osu-combo-500",
             "500 Combo",
             "Achieve a 500 combo.",

--- a/tests/unit/score_submission_usecase_test.py
+++ b/tests/unit/score_submission_usecase_test.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date
+from datetime import datetime
+from ipaddress import IPv4Address
+from types import SimpleNamespace
+
+import pytest
+
+from app.constants.clientflags import ClientFlags
+from app.constants.gamemodes import GameMode
+from app.constants.mods import Mods
+from app.objects.player import ClientDetails
+from app.objects.player import ModeData
+from app.objects.player import OsuStream
+from app.objects.player import OsuVersion
+from app.objects.score import Grade
+from app.objects.score import Score
+from app.usecases import score_submission
+
+
+def _md5(value: str) -> str:
+    return hashlib.md5(value.encode()).hexdigest()
+
+
+def _client_details() -> ClientDetails:
+    return ClientDetails(
+        osu_version=OsuVersion(
+            date=date(2024, 1, 2),
+            revision=None,
+            stream=OsuStream.STABLE,
+        ),
+        osu_path_md5="osu-path",
+        adapters_md5="adapters",
+        uninstall_md5=_md5("unique1"),
+        disk_signature_md5=_md5("unique2"),
+        adapters=["adapter1", "adapter2"],
+        ip=IPv4Address("127.0.0.1"),
+    )
+
+
+def _score() -> Score:
+    score = Score()
+    score.id = 42
+    score.n300 = 83
+    score.n100 = 14
+    score.n50 = 5
+    score.ngeki = 23
+    score.nkatu = 6
+    score.nmiss = 6
+    score.score = 26_810
+    score.max_combo = 52
+    score.perfect = False
+    score.grade = Grade.C
+    score.mods = Mods.HIDDEN | Mods.RELAX
+    score.passed = True
+    score.mode = GameMode.RELAX_OSU
+    score.client_time = datetime(2024, 1, 1, 12, 0, 0)
+    score.server_time = score.client_time
+    score.time_elapsed = 13_358
+    score.client_flags = ClientFlags(0)
+    score.acc = 81.94
+    score.pp = 10.448
+    score.rank = 1
+    score.prev_best = None
+    score.client_checksum = ""
+    score.player = SimpleNamespace(id=6, name="test-user")
+    score.bmap = SimpleNamespace(
+        id=315,
+        set_id=141,
+        md5="1cf5b2c2edfafd055536d2cefcb89c0e",
+        plays=1,
+        passes=1,
+        last_update="2014-05-18 15:41:48",
+        set=SimpleNamespace(url="https://osu.cmyui.xyz/s/141"),
+    )
+    return score
+
+
+def _stats() -> tuple[ModeData, ModeData]:
+    previous = ModeData(
+        tscore=0,
+        rscore=0,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=0,
+        total_hits=0,
+        rank=0,
+        grades={},
+    )
+    current = ModeData(
+        tscore=26_810,
+        rscore=26_810,
+        pp=11,
+        acc=81.94,
+        plays=1,
+        playtime=13,
+        max_combo=52,
+        total_hits=102,
+        rank=1,
+        grades={},
+    )
+    return previous, current
+
+
+def test_parse_unique_id_hashes_md5s_submission_unique_ids() -> None:
+    unique_id_hashes = score_submission.parse_unique_id_hashes("unique1|unique2")
+
+    assert unique_id_hashes == score_submission.UniqueIdHashes(
+        unique_id1_md5=_md5("unique1"),
+        unique_id2_md5=_md5("unique2"),
+    )
+
+
+def test_validate_client_details_accepts_matching_login_and_submission_data() -> None:
+    client_details = _client_details()
+
+    score_submission.validate_client_details(
+        client_details=client_details,
+        osu_version="20240102",
+        client_hash=client_details.client_hash,
+        unique_id_hashes=score_submission.parse_unique_id_hashes("unique1|unique2"),
+    )
+
+
+def test_validate_client_details_rejects_missing_client_details() -> None:
+    with pytest.raises(ValueError, match="missing client details"):
+        score_submission.validate_client_details(
+            client_details=None,
+            osu_version="20240102",
+            client_hash="client-hash",
+            unique_id_hashes=score_submission.parse_unique_id_hashes("unique1|unique2"),
+        )
+
+
+@pytest.mark.parametrize(
+    ("osu_version", "client_hash", "unique_ids", "expected_error"),
+    [
+        ("20240101", None, "unique1|unique2", "osu! version mismatch"),
+        ("20240102", "wrong-hash", "unique1|unique2", "client hash mismatch"),
+        ("20240102", None, "wrong|unique2", "unique_id1 mismatch"),
+        ("20240102", None, "unique1|wrong", "unique_id2 mismatch"),
+    ],
+)
+def test_validate_client_details_rejects_mismatched_submission_data(
+    osu_version: str,
+    client_hash: str | None,
+    unique_ids: str,
+    expected_error: str,
+) -> None:
+    client_details = _client_details()
+    if client_hash is None:
+        client_hash = client_details.client_hash
+
+    with pytest.raises(ValueError, match=expected_error):
+        score_submission.validate_client_details(
+            client_details=client_details,
+            osu_version=osu_version,
+            client_hash=client_hash,
+            unique_id_hashes=score_submission.parse_unique_id_hashes(unique_ids),
+        )
+
+
+def test_validate_submission_integrity_accepts_matching_submission_data() -> None:
+    client_details = _client_details()
+    score = _score()
+    score.client_checksum = score.compute_online_checksum(
+        osu_version="20240102",
+        osu_client_hash=client_details.client_hash,
+        storyboard_checksum="storyboard",
+    )
+
+    score_submission.validate_submission_integrity(
+        client_details=client_details,
+        osu_version="20240102",
+        client_hash=client_details.client_hash,
+        unique_ids="unique1|unique2",
+        score=score,
+        storyboard_md5="storyboard",
+        submission_beatmap_md5="1cf5b2c2edfafd055536d2cefcb89c0e",
+        updated_beatmap_hash="1cf5b2c2edfafd055536d2cefcb89c0e",
+    )
+
+
+def test_validate_submission_integrity_rejects_mismatched_score_checksum() -> None:
+    client_details = _client_details()
+    score = _score()
+    score.client_checksum = "wrong-checksum"
+
+    with pytest.raises(ValueError, match="online score checksum mismatch"):
+        score_submission.validate_submission_integrity(
+            client_details=client_details,
+            osu_version="20240102",
+            client_hash=client_details.client_hash,
+            unique_ids="unique1|unique2",
+            score=score,
+            storyboard_md5="storyboard",
+            submission_beatmap_md5="1cf5b2c2edfafd055536d2cefcb89c0e",
+            updated_beatmap_hash="1cf5b2c2edfafd055536d2cefcb89c0e",
+        )
+
+
+def test_validate_submission_integrity_rejects_mismatched_beatmap_hash() -> None:
+    client_details = _client_details()
+    score = _score()
+    score.client_checksum = score.compute_online_checksum(
+        osu_version="20240102",
+        osu_client_hash=client_details.client_hash,
+        storyboard_checksum="storyboard",
+    )
+
+    with pytest.raises(ValueError, match="beatmap hash mismatch"):
+        score_submission.validate_submission_integrity(
+            client_details=client_details,
+            osu_version="20240102",
+            client_hash=client_details.client_hash,
+            unique_ids="unique1|unique2",
+            score=score,
+            storyboard_md5="storyboard",
+            submission_beatmap_md5="1cf5b2c2edfafd055536d2cefcb89c0e",
+            updated_beatmap_hash="wrong-md5",
+        )
+
+
+def test_build_submission_charts_formats_osu_client_response() -> None:
+    score = _score()
+    previous_stats, current_stats = _stats()
+    achievements = [
+        {
+            "id": 1,
+            "file": "osu-skill-pass-4",
+            "name": "Insanity Approaches",
+            "desc": "You're not twitching, you're just ready.",
+            "cond": lambda score, mode_vn: True,
+        },
+        {
+            "id": 2,
+            "file": "all-intro-hidden",
+            "name": "Blindsight",
+            "desc": "I can see just perfectly",
+            "cond": lambda score, mode_vn: True,
+        },
+    ]
+
+    response = score_submission.build_submission_charts(
+        score=score,
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+        achievements=achievements,
+        domain="cmyui.xyz",
+    )
+
+    assert response == (
+        b"beatmapId:315|beatmapSetId:141|beatmapPlaycount:1|beatmapPasscount:1|approvedDate:2014-05-18 15:41:48|\n"
+        b"|chartId:beatmap|chartUrl:https://osu.cmyui.xyz/s/141|chartName:Beatmap Ranking|rankBefore:|rankAfter:1|rankedScoreBefore:|rankedScoreAfter:26810|totalScoreBefore:|totalScoreAfter:26810|maxComboBefore:|maxComboAfter:52|accuracyBefore:|accuracyAfter:81.94|ppBefore:|ppAfter:10.448|onlineScoreId:42|\n"
+        b"|chartId:overall|chartUrl:https://cmyui.xyz/u/6|chartName:Overall Ranking|rankBefore:|rankAfter:1|rankedScoreBefore:|rankedScoreAfter:26810|totalScoreBefore:|totalScoreAfter:26810|maxComboBefore:|maxComboAfter:52|accuracyBefore:|accuracyAfter:81.94|ppBefore:|ppAfter:11|achievements-new:osu-skill-pass-4+Insanity Approaches+You're not twitching, you're just ready./all-intro-hidden+Blindsight+I can see just perfectly"
+    )
+
+
+def test_build_submission_charts_includes_previous_best_values() -> None:
+    score = _score()
+    previous_best = Score()
+    previous_best.rank = 4
+    previous_best.score = 20_000
+    previous_best.max_combo = 40
+    previous_best.acc = 80.123
+    previous_best.pp = 9.5
+    score.prev_best = previous_best
+    previous_stats, current_stats = _stats()
+
+    response = score_submission.build_submission_charts(
+        score=score,
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+        achievements=[],
+        domain="cmyui.xyz",
+    )
+
+    assert (
+        b"rankBefore:4|rankAfter:1|rankedScoreBefore:20000|rankedScoreAfter:26810"
+        in response
+    )
+    assert (
+        b"accuracyBefore:80.12|accuracyAfter:81.94|ppBefore:9.5|ppAfter:10.448"
+        in response
+    )


### PR DESCRIPTION
## Summary
- extract score submission client/hash validation into a dedicated usecase module
- extract osu! score submission chart formatting into the same usecase module
- add focused unit coverage for unique-id hashing, client detail validation, checksum/hash failures, achievements, and chart output with/without previous bests
- keep the existing score submission integration test as the route-level contract check

## Verification
- uv run --frozen --env-file .env.test pytest tests/unit/domain_helpers_test.py tests/unit/score_submission_usecase_test.py -q
- make lint
- make type-check
- make test