### PR TITLE
refactor: extract score submission response flow

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -68,7 +68,6 @@ from app.repositories import ratings as ratings_repo
 from app.repositories import scores as scores_repo
 from app.repositories import stats as stats_repo
 from app.repositories import users as users_repo
-from app.repositories.achievements import Achievement
 from app.usecases import achievements as achievements_usecases
 from app.usecases import score_submission as score_submission_usecases
 from app.usecases import user_achievements as user_achievements_usecases
@@ -933,51 +932,14 @@ async def osuSubmitModularSelector(
     # update their recent score
     score.player.recent_scores[score.mode] = score
 
-    """ score submission charts """
-
-    # charts are only displayed for passes vanilla gamemodes.
-    if not score.passed:  # TODO: check if this is correct
-        response = b"error: no"
-    else:
-        # construct and send achievements & ranking charts to the client
-        if score.bmap.awards_ranked_pp and not score.player.restricted:
-            unlocked_achievements: list[Achievement] = []
-
-            server_achievements = await achievements_usecases.fetch_many()
-            player_achievements = await user_achievements_usecases.fetch_many(
-                user_id=score.player.id,
-            )
-
-            for server_achievement in server_achievements:
-                player_unlocked_achievement = any(
-                    player_achievement
-                    for player_achievement in player_achievements
-                    if player_achievement["achid"] == server_achievement["id"]
-                )
-                if player_unlocked_achievement:
-                    # player already has this achievement.
-                    continue
-
-                achievement_condition = server_achievement["cond"]
-                if achievement_condition(score, score.mode.as_vanilla):
-                    await user_achievements_usecases.create(
-                        score.player.id,
-                        server_achievement["id"],
-                    )
-                    unlocked_achievements.append(server_achievement)
-
-            achievements = unlocked_achievements
-        else:
-            achievements = []
-
-        # create score submission charts for osu! client to display
-        response = score_submission_usecases.build_submission_charts(
-            score=score,
-            previous_stats=prev_stats,
-            current_stats=stats,
-            achievements=achievements,
-            domain=app.settings.DOMAIN,
-        )
+    response = await score_submission_usecases.build_score_submission_response(
+        score=score,
+        previous_stats=prev_stats,
+        current_stats=stats,
+        domain=app.settings.DOMAIN,
+        achievements=achievements_usecases,
+        user_achievements=user_achievements_usecases,
+    )
 
     log(
         f"[{score.mode!r}] {score.player} submitted a score! "

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -3,11 +3,27 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Protocol
 
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
 from app.objects.score import Score
 from app.repositories.achievements import Achievement
+from app.repositories.user_achievements import UserAchievement
+
+
+class AchievementsService(Protocol):
+    async def fetch_many(self) -> Sequence[Achievement]: ...
+
+
+class UserAchievementsService(Protocol):
+    async def fetch_many(self, *, user_id: int) -> Sequence[UserAchievement]: ...
+
+    async def create(
+        self,
+        user_id: int,
+        achievement_id: int,
+    ) -> UserAchievement: ...
 
 
 @dataclass(frozen=True)
@@ -133,6 +149,43 @@ def format_achievements(achievements: Sequence[Achievement]) -> str:
     )
 
 
+def achievement_is_unlocked(
+    achievement: Achievement,
+    user_achievements: Sequence[UserAchievement],
+) -> bool:
+    return any(
+        user_achievement["achid"] == achievement["id"]
+        for user_achievement in user_achievements
+    )
+
+
+async def unlock_new_achievements(
+    *,
+    score: Score,
+    achievements: AchievementsService,
+    user_achievements: UserAchievementsService,
+) -> list[Achievement]:
+    assert score.player is not None
+
+    unlocked_achievements: list[Achievement] = []
+    server_achievements = await achievements.fetch_many()
+    player_achievements = await user_achievements.fetch_many(user_id=score.player.id)
+
+    for server_achievement in server_achievements:
+        if achievement_is_unlocked(server_achievement, player_achievements):
+            continue
+
+        achievement_condition = server_achievement["cond"]
+        if achievement_condition(score, score.mode.as_vanilla):
+            await user_achievements.create(
+                score.player.id,
+                server_achievement["id"],
+            )
+            unlocked_achievements.append(server_achievement)
+
+    return unlocked_achievements
+
+
 def build_submission_charts(
     *,
     score: Score,
@@ -200,3 +253,36 @@ def build_submission_charts(
     ]
 
     return "|".join(submission_charts).encode()
+
+
+async def build_score_submission_response(
+    *,
+    score: Score,
+    previous_stats: ModeData,
+    current_stats: ModeData,
+    domain: str,
+    achievements: AchievementsService,
+    user_achievements: UserAchievementsService,
+) -> bytes:
+    if not score.passed:  # TODO: check if this is correct
+        return b"error: no"
+
+    assert score.bmap is not None
+    assert score.player is not None
+
+    if score.bmap.awards_ranked_pp and not score.player.restricted:
+        unlocked_achievements = await unlock_new_achievements(
+            score=score,
+            achievements=achievements,
+            user_achievements=user_achievements,
+        )
+    else:
+        unlocked_achievements = []
+
+    return build_submission_charts(
+        score=score,
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+        achievements=unlocked_achievements,
+        domain=domain,
+    )

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -65,7 +65,7 @@ def _score() -> Score:
     score.rank = 1
     score.prev_best = None
     score.client_checksum = ""
-    score.player = SimpleNamespace(id=6, name="test-user")
+    score.player = SimpleNamespace(id=6, name="test-user", restricted=False)
     score.bmap = SimpleNamespace(
         id=315,
         set_id=141,
@@ -73,6 +73,7 @@ def _score() -> Score:
         plays=1,
         passes=1,
         last_update="2014-05-18 15:41:48",
+        awards_ranked_pp=True,
         set=SimpleNamespace(url="https://osu.cmyui.xyz/s/141"),
     )
     return score
@@ -104,6 +105,76 @@ def _stats() -> tuple[ModeData, ModeData]:
         grades={},
     )
     return previous, current
+
+
+class _FailingAchievements:
+    async def fetch_many(self) -> list[dict[str, object]]:
+        raise AssertionError("achievements should not be fetched")
+
+
+class _FailingUserAchievements:
+    async def fetch_many(
+        self,
+        *,
+        user_id: int,
+    ) -> list[dict[str, int]]:
+        raise AssertionError("user achievements should not be fetched")
+
+    async def create(
+        self,
+        user_id: int,
+        achievement_id: int,
+    ) -> dict[str, int]:
+        raise AssertionError("user achievements should not be created")
+
+
+class _FakeAchievements:
+    async def fetch_many(self) -> list[dict[str, object]]:
+        return [
+            {
+                "id": 1,
+                "file": "osu-skill-pass-4",
+                "name": "Insanity Approaches",
+                "desc": "You're not twitching, you're just ready.",
+                "cond": lambda score, mode_vn: True,
+            },
+            {
+                "id": 2,
+                "file": "osu-combo-500",
+                "name": "500 Combo",
+                "desc": "Achieve a 500 combo.",
+                "cond": lambda score, mode_vn: False,
+            },
+            {
+                "id": 3,
+                "file": "all-intro-hidden",
+                "name": "Blindsight",
+                "desc": "I can see just perfectly",
+                "cond": lambda score, mode_vn: True,
+            },
+        ]
+
+
+class _FakeUserAchievements:
+    def __init__(self) -> None:
+        self.created_achievement_ids: list[int] = []
+
+    async def fetch_many(
+        self,
+        *,
+        user_id: int,
+    ) -> list[dict[str, int]]:
+        assert user_id == 6
+        return [{"userid": 6, "achid": 3}]
+
+    async def create(
+        self,
+        user_id: int,
+        achievement_id: int,
+    ) -> dict[str, int]:
+        assert user_id == 6
+        self.created_achievement_ids.append(achievement_id)
+        return {"userid": user_id, "achid": achievement_id}
 
 
 def test_parse_unique_id_hashes_md5s_submission_unique_ids() -> None:
@@ -304,3 +375,74 @@ def test_build_submission_charts_includes_previous_best_values() -> None:
         b"accuracyBefore:80.12|accuracyAfter:81.94|ppBefore:9.5|ppAfter:10.448"
         in response
     )
+
+
+async def test_build_score_submission_response_returns_error_for_failed_score() -> None:
+    score = _score()
+    score.passed = False
+    previous_stats, current_stats = _stats()
+
+    response = await score_submission.build_score_submission_response(
+        score=score,
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+        domain="cmyui.xyz",
+        achievements=_FailingAchievements(),
+        user_achievements=_FailingUserAchievements(),
+    )
+
+    assert response == b"error: no"
+
+
+@pytest.mark.parametrize(
+    ("awards_ranked_pp", "restricted"),
+    [
+        (False, False),
+        (True, True),
+    ],
+)
+async def test_build_score_submission_response_skips_achievements_when_score_is_not_eligible(
+    awards_ranked_pp: bool,
+    restricted: bool,
+) -> None:
+    score = _score()
+    score.bmap.awards_ranked_pp = awards_ranked_pp
+    score.player.restricted = restricted
+    previous_stats, current_stats = _stats()
+
+    response = await score_submission.build_score_submission_response(
+        score=score,
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+        domain="cmyui.xyz",
+        achievements=_FailingAchievements(),
+        user_achievements=_FailingUserAchievements(),
+    )
+
+    assert b"achievements-new:" in response
+    assert b"osu-skill-pass-4" not in response
+
+
+async def test_build_score_submission_response_unlocks_matching_new_achievements() -> (
+    None
+):
+    score = _score()
+    previous_stats, current_stats = _stats()
+    user_achievements = _FakeUserAchievements()
+
+    response = await score_submission.build_score_submission_response(
+        score=score,
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+        domain="cmyui.xyz",
+        achievements=_FakeAchievements(),
+        user_achievements=user_achievements,
+    )
+
+    assert user_achievements.created_achievement_ids == [1]
+    assert (
+        b"achievements-new:osu-skill-pass-4+Insanity Approaches+You're not twitching, you're just ready."
+        in response
+    )
+    assert b"osu-combo-500" not in response
+    assert b"all-intro-hidden" not in response


### PR DESCRIPTION
## Summary
- move score submission response and achievement-unlock decisions into `app/usecases/score_submission.py`
- define role-based `AchievementsService` / `UserAchievementsService` protocols and pass the existing usecase modules through them
- add focused unit coverage for failed submissions, ineligible achievement paths, and new achievement unlocks

## Verification
- `uv run --frozen --env-file .env.test pytest tests/unit/usecases/score_submission_test.py -q`
- `make utest`
- `make type-check`
- `make lint`
- `make test`