### PR TITLE
refactor: extract score submission stats helpers

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -56,7 +56,6 @@ from app.objects.beatmap import Beatmap
 from app.objects.beatmap import RankedStatus
 from app.objects.beatmap import ensure_osu_file_is_available
 from app.objects.player import Player
-from app.objects.score import Grade
 from app.objects.score import Score
 from app.objects.score import SubmissionStatus
 from app.repositories import clans as clans_repo
@@ -806,61 +805,15 @@ async def osuSubmitModularSelector(
     stats = score.player.stats[score.mode]
     prev_stats = copy.copy(stats)
 
-    # stuff update for all submitted scores
-    stats.playtime += score.time_elapsed // 1000
-    stats.plays += 1
-    stats.tscore += score.score
-    stats.total_hits += score.n300 + score.n100 + score.n50
-
-    if score.mode.as_vanilla in (1, 3):
-        # taiko uses geki & katu for hitting big notes with 2 keys
-        # mania uses geki & katu for rainbow 300 & 200
-        stats.total_hits += score.ngeki + score.nkatu
-
-    stats_updates: dict[str, Any] = {
-        "plays": stats.plays,
-        "playtime": stats.playtime,
-        "tscore": stats.tscore,
-        "total_hits": stats.total_hits,
-    }
+    stats_updates = score_submission_usecases.apply_score_stats(score, stats)
 
     if score.passed and score.bmap.has_leaderboard:
         # player passed & map is ranked, approved, or loved.
 
-        if score.max_combo > stats.max_combo:
-            stats.max_combo = score.max_combo
-            stats_updates["max_combo"] = stats.max_combo
-
         if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
             # map is ranked or approved, and it's our (new)
-            # best score on the map. update the player's
-            # ranked score, grades, pp, acc and global rank.
-
-            additional_rscore = score.score
-            if score.prev_best:
-                # we previously had a score, so remove
-                # it's score from our ranked score.
-                additional_rscore -= score.prev_best.score
-
-                if score.grade != score.prev_best.grade:
-                    if score.grade >= Grade.A:
-                        stats.grades[score.grade] += 1
-                        grade_col = format(score.grade, "stats_column")
-                        stats_updates[grade_col] = stats.grades[score.grade]
-
-                    if score.prev_best.grade >= Grade.A:
-                        stats.grades[score.prev_best.grade] -= 1
-                        grade_col = format(score.prev_best.grade, "stats_column")
-                        stats_updates[grade_col] = stats.grades[score.prev_best.grade]
-            else:
-                # this is our first submitted score on the map
-                if score.grade >= Grade.A:
-                    stats.grades[score.grade] += 1
-                    grade_col = format(score.grade, "stats_column")
-                    stats_updates[grade_col] = stats.grades[score.grade]
-
-            stats.rscore += additional_rscore
-            stats_updates["rscore"] = stats.rscore
+            # best score on the map. update the player's pp,
+            # acc and global rank.
 
             # fetch scores sorted by pp for total acc/pp calc
             # NOTE: we select all plays (and not just top100)
@@ -876,19 +829,12 @@ async def osuSubmitModularSelector(
                 {"user_id": score.player.id, "mode": score.mode},
             )
 
-            # calculate new total weighted accuracy
-            weighted_acc = sum(
-                row["acc"] * 0.95**i for i, row in enumerate(best_scores)
+            stats_updates.update(
+                score_submission_usecases.apply_weighted_performance_stats(
+                    stats,
+                    best_scores,
+                ),
             )
-            bonus_acc = 100.0 / (20 * (1 - 0.95 ** len(best_scores)))
-            stats.acc = (weighted_acc * bonus_acc) / 100
-            stats_updates["acc"] = stats.acc
-
-            # calculate new total weighted pp
-            weighted_pp = sum(row["pp"] * 0.95**i for i, row in enumerate(best_scores))
-            bonus_pp = 416.6667 * (1 - 0.9994 ** len(best_scores))
-            stats.pp = round(weighted_pp + bonus_pp)
-            stats_updates["pp"] = stats.pp
 
             # update global & country ranking
             stats.rank = await score.player.update_rank(score.mode)

--- a/app/objects/score.py
+++ b/app/objects/score.py
@@ -57,12 +57,6 @@ class Grade(IntEnum):
             "n": Grade.N,
         }[s.lower()]
 
-    def __format__(self, format_spec: str) -> str:
-        if format_spec == "stats_column":
-            return f"{self.name.lower()}_count"
-        else:
-            raise ValueError(f"Invalid format specifier {format_spec}")
-
 
 @unique
 @pymysql_encode(escape_enum)

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -212,8 +212,11 @@ def apply_score_stats(score: Score, stats: ModeData) -> StatsUpdates:
         stats.max_combo = score.max_combo
         updates["max_combo"] = stats.max_combo
 
-    if score.status == SubmissionStatus.BEST:
-        # Map has an online leaderboard, and this is our (new)
+    if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
+        # Official osu! includes loved maps in ranked score and grade counts.
+        # bancho.py has historically counted only ranked/approved maps here;
+        # expanding this would require a stats backfill for existing users.
+        # Map is ranked or approved, and this is our (new)
         # best score on the map. Update the player's
         # ranked score and grade counts.
         updates.update(apply_ranked_score_stats(score, stats))

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -212,8 +212,8 @@ def apply_score_stats(score: Score, stats: ModeData) -> StatsUpdates:
         stats.max_combo = score.max_combo
         updates["max_combo"] = stats.max_combo
 
-    if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
-        # Map is ranked or approved, and this is our (new)
+    if score.status == SubmissionStatus.BEST:
+        # Map has an online leaderboard, and this is our (new)
         # best score on the map. Update the player's
         # ranked score and grade counts.
         updates.update(apply_ranked_score_stats(score, stats))

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -17,6 +17,13 @@ from app.repositories.user_achievements import UserAchievement
 
 StatsUpdates = dict[str, Any]
 BestScorePerformance = Mapping[str, float]
+GRADE_STATS_COLUMNS = {
+    Grade.XH: "xh_count",
+    Grade.X: "x_count",
+    Grade.SH: "sh_count",
+    Grade.S: "s_count",
+    Grade.A: "a_count",
+}
 
 
 class AchievementsService(Protocol):
@@ -134,12 +141,15 @@ def validate_submission_integrity(
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:
+    # Stats updated for all submitted scores.
     stats.playtime += score.time_elapsed // 1000
     stats.plays += 1
     stats.tscore += score.score
     stats.total_hits += score.n300 + score.n100 + score.n50
 
     if score.mode.as_vanilla in (1, 3):
+        # Taiko uses geki & katu for hitting big notes with 2 keys;
+        # mania uses geki & katu for rainbow 300 & 200.
         stats.total_hits += score.ngeki + score.nkatu
 
     return {
@@ -150,43 +160,39 @@ def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:
     }
 
 
-def update_grade_count(
-    stats: ModeData,
-    grade: Grade,
-    delta: int,
-) -> tuple[str, int] | None:
-    if grade < Grade.A:
-        return None
+def ranked_score_delta(score: Score) -> int:
+    if score.prev_best is None:
+        return score.score
 
-    stats.grades[grade] += delta
-    grade_column = format(grade, "stats_column")
-    return grade_column, stats.grades[grade]
+    # We previously had a score, so remove its score from our ranked score.
+    return score.score - score.prev_best.score
+
+
+def grade_count_deltas(score: Score) -> dict[Grade, int]:
+    if score.prev_best is None:
+        # This is our first submitted score on the map.
+        return {score.grade: 1} if score.grade >= Grade.A else {}
+
+    if score.grade == score.prev_best.grade:
+        return {}
+
+    deltas: dict[Grade, int] = {}
+    if score.grade >= Grade.A:
+        deltas[score.grade] = 1
+    if score.prev_best.grade >= Grade.A:
+        deltas[score.prev_best.grade] = deltas.get(score.prev_best.grade, 0) - 1
+
+    return deltas
 
 
 def apply_ranked_score_stats(score: Score, stats: ModeData) -> StatsUpdates:
     updates: StatsUpdates = {}
-    additional_rscore = score.score
 
-    if score.prev_best:
-        additional_rscore -= score.prev_best.score
+    for grade, delta in grade_count_deltas(score).items():
+        stats.grades[grade] += delta
+        updates[GRADE_STATS_COLUMNS[grade]] = stats.grades[grade]
 
-        if score.grade != score.prev_best.grade:
-            grade_update = update_grade_count(stats, score.grade, 1)
-            if grade_update is not None:
-                grade_column, grade_count = grade_update
-                updates[grade_column] = grade_count
-
-            previous_grade_update = update_grade_count(stats, score.prev_best.grade, -1)
-            if previous_grade_update is not None:
-                grade_column, grade_count = previous_grade_update
-                updates[grade_column] = grade_count
-    else:
-        grade_update = update_grade_count(stats, score.grade, 1)
-        if grade_update is not None:
-            grade_column, grade_count = grade_update
-            updates[grade_column] = grade_count
-
-    stats.rscore += additional_rscore
+    stats.rscore += ranked_score_delta(score)
     updates["rscore"] = stats.rscore
 
     return updates
@@ -207,18 +213,23 @@ def apply_score_stats(score: Score, stats: ModeData) -> StatsUpdates:
         updates["max_combo"] = stats.max_combo
 
     if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
+        # Map is ranked or approved, and this is our (new)
+        # best score on the map. Update the player's
+        # ranked score and grade counts.
         updates.update(apply_ranked_score_stats(score, stats))
 
     return updates
 
 
 def calculate_weighted_accuracy(best_scores: Sequence[BestScorePerformance]) -> float:
+    # Calculate new total weighted accuracy.
     weighted_acc = sum(row["acc"] * 0.95**i for i, row in enumerate(best_scores))
     bonus_acc = 100.0 / (20 * (1 - 0.95 ** len(best_scores)))
     return (weighted_acc * bonus_acc) / 100
 
 
 def calculate_weighted_pp(best_scores: Sequence[BestScorePerformance]) -> int:
+    # Calculate new total weighted pp.
     weighted_pp = sum(row["pp"] * 0.95**i for i, row in enumerate(best_scores))
     bonus_pp = 416.6667 * (1 - 0.9994 ** len(best_scores))
     return round(weighted_pp + bonus_pp)

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Any
 from typing import Protocol
 
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
+from app.objects.score import Grade
 from app.objects.score import Score
+from app.objects.score import SubmissionStatus
 from app.repositories.achievements import Achievement
 from app.repositories.user_achievements import UserAchievement
+
+StatsUpdates = dict[str, Any]
+BestScorePerformance = Mapping[str, float]
 
 
 class AchievementsService(Protocol):
@@ -124,6 +131,110 @@ def validate_submission_integrity(
         submission_beatmap_md5=submission_beatmap_md5,
         updated_beatmap_hash=updated_beatmap_hash,
     )
+
+
+def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:
+    stats.playtime += score.time_elapsed // 1000
+    stats.plays += 1
+    stats.tscore += score.score
+    stats.total_hits += score.n300 + score.n100 + score.n50
+
+    if score.mode.as_vanilla in (1, 3):
+        stats.total_hits += score.ngeki + score.nkatu
+
+    return {
+        "plays": stats.plays,
+        "playtime": stats.playtime,
+        "tscore": stats.tscore,
+        "total_hits": stats.total_hits,
+    }
+
+
+def update_grade_count(
+    stats: ModeData,
+    grade: Grade,
+    delta: int,
+) -> tuple[str, int] | None:
+    if grade < Grade.A:
+        return None
+
+    stats.grades[grade] += delta
+    grade_column = format(grade, "stats_column")
+    return grade_column, stats.grades[grade]
+
+
+def apply_ranked_score_stats(score: Score, stats: ModeData) -> StatsUpdates:
+    updates: StatsUpdates = {}
+    additional_rscore = score.score
+
+    if score.prev_best:
+        additional_rscore -= score.prev_best.score
+
+        if score.grade != score.prev_best.grade:
+            grade_update = update_grade_count(stats, score.grade, 1)
+            if grade_update is not None:
+                grade_column, grade_count = grade_update
+                updates[grade_column] = grade_count
+
+            previous_grade_update = update_grade_count(stats, score.prev_best.grade, -1)
+            if previous_grade_update is not None:
+                grade_column, grade_count = previous_grade_update
+                updates[grade_column] = grade_count
+    else:
+        grade_update = update_grade_count(stats, score.grade, 1)
+        if grade_update is not None:
+            grade_column, grade_count = grade_update
+            updates[grade_column] = grade_count
+
+    stats.rscore += additional_rscore
+    updates["rscore"] = stats.rscore
+
+    return updates
+
+
+def apply_score_stats(score: Score, stats: ModeData) -> StatsUpdates:
+    updates = apply_score_base_stats(score, stats)
+
+    if not score.passed:
+        return updates
+
+    assert score.bmap is not None
+    if not score.bmap.has_leaderboard:
+        return updates
+
+    if score.max_combo > stats.max_combo:
+        stats.max_combo = score.max_combo
+        updates["max_combo"] = stats.max_combo
+
+    if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
+        updates.update(apply_ranked_score_stats(score, stats))
+
+    return updates
+
+
+def calculate_weighted_accuracy(best_scores: Sequence[BestScorePerformance]) -> float:
+    weighted_acc = sum(row["acc"] * 0.95**i for i, row in enumerate(best_scores))
+    bonus_acc = 100.0 / (20 * (1 - 0.95 ** len(best_scores)))
+    return (weighted_acc * bonus_acc) / 100
+
+
+def calculate_weighted_pp(best_scores: Sequence[BestScorePerformance]) -> int:
+    weighted_pp = sum(row["pp"] * 0.95**i for i, row in enumerate(best_scores))
+    bonus_pp = 416.6667 * (1 - 0.9994 ** len(best_scores))
+    return round(weighted_pp + bonus_pp)
+
+
+def apply_weighted_performance_stats(
+    stats: ModeData,
+    best_scores: Sequence[BestScorePerformance],
+) -> StatsUpdates:
+    stats.acc = calculate_weighted_accuracy(best_scores)
+    stats.pp = calculate_weighted_pp(best_scores)
+
+    return {
+        "acc": stats.acc,
+        "pp": stats.pp,
+    }
 
 
 def chart_entry(

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -17,6 +17,7 @@ from app.objects.player import OsuStream
 from app.objects.player import OsuVersion
 from app.objects.score import Grade
 from app.objects.score import Score
+from app.objects.score import SubmissionStatus
 from app.usecases import score_submission
 
 
@@ -55,6 +56,7 @@ def _score() -> Score:
     score.grade = Grade.C
     score.mods = Mods.HIDDEN | Mods.RELAX
     score.passed = True
+    score.status = SubmissionStatus.BEST
     score.mode = GameMode.RELAX_OSU
     score.client_time = datetime(2024, 1, 1, 12, 0, 0)
     score.server_time = score.client_time
@@ -73,10 +75,28 @@ def _score() -> Score:
         plays=1,
         passes=1,
         last_update="2014-05-18 15:41:48",
+        has_leaderboard=True,
         awards_ranked_pp=True,
         set=SimpleNamespace(url="https://osu.cmyui.xyz/s/141"),
     )
     return score
+
+
+def _grade_counts(
+    *,
+    xh: int = 0,
+    x: int = 0,
+    sh: int = 0,
+    s: int = 0,
+    a: int = 0,
+) -> dict[Grade, int]:
+    return {
+        Grade.XH: xh,
+        Grade.X: x,
+        Grade.SH: sh,
+        Grade.S: s,
+        Grade.A: a,
+    }
 
 
 def _stats() -> tuple[ModeData, ModeData]:
@@ -311,6 +331,183 @@ def test_validate_submission_integrity_rejects_mismatched_beatmap_hash() -> None
             submission_beatmap_md5="1cf5b2c2edfafd055536d2cefcb89c0e",
             updated_beatmap_hash="wrong-md5",
         )
+
+
+def test_apply_score_stats_updates_base_stats_for_failed_score() -> None:
+    score = _score()
+    score.passed = False
+    score.mode = GameMode.VANILLA_OSU
+    score.time_elapsed = 2_500
+    score.score = 1_000
+    score.n300 = 3
+    score.n100 = 2
+    score.n50 = 1
+    stats = ModeData(
+        tscore=10,
+        rscore=20,
+        pp=30,
+        acc=40.0,
+        plays=2,
+        playtime=5,
+        max_combo=100,
+        total_hits=7,
+        rank=50,
+        grades=_grade_counts(),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.plays == 3
+    assert stats.playtime == 7
+    assert stats.tscore == 1_010
+    assert stats.total_hits == 13
+    assert updates == {
+        "plays": 3,
+        "playtime": 7,
+        "tscore": 1_010,
+        "total_hits": 13,
+    }
+
+
+def test_apply_score_stats_counts_taiko_and_mania_bonus_hits() -> None:
+    score = _score()
+    score.passed = False
+    score.mode = GameMode.VANILLA_TAIKO
+    stats = ModeData(
+        tscore=0,
+        rscore=0,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=0,
+        total_hits=0,
+        rank=0,
+        grades=_grade_counts(),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.total_hits == 131
+    assert updates["total_hits"] == 131
+
+
+def test_apply_score_stats_skips_leaderboard_stats_without_leaderboard() -> None:
+    score = _score()
+    score.bmap.has_leaderboard = False
+    score.score = 50_000
+    score.max_combo = 300
+    score.grade = Grade.S
+    stats = ModeData(
+        tscore=0,
+        rscore=1_000,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=100,
+        total_hits=0,
+        rank=0,
+        grades=_grade_counts(s=1),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.max_combo == 100
+    assert stats.rscore == 1_000
+    assert stats.grades[Grade.S] == 1
+    assert "max_combo" not in updates
+    assert "rscore" not in updates
+    assert "s_count" not in updates
+
+
+def test_apply_score_stats_updates_first_best_ranked_score() -> None:
+    score = _score()
+    score.score = 50_000
+    score.max_combo = 300
+    score.grade = Grade.S
+    stats = ModeData(
+        tscore=0,
+        rscore=1_000,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=100,
+        total_hits=0,
+        rank=0,
+        grades=_grade_counts(s=1),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.max_combo == 300
+    assert stats.rscore == 51_000
+    assert stats.grades[Grade.S] == 2
+    assert updates["max_combo"] == 300
+    assert updates["rscore"] == 51_000
+    assert updates["s_count"] == 2
+
+
+def test_apply_score_stats_replaces_previous_best_ranked_score_and_grades() -> None:
+    score = _score()
+    score.score = 30_000
+    score.max_combo = 50
+    score.grade = Grade.S
+    previous_best = Score()
+    previous_best.score = 20_000
+    previous_best.grade = Grade.A
+    score.prev_best = previous_best
+    stats = ModeData(
+        tscore=0,
+        rscore=50_000,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=100,
+        total_hits=0,
+        rank=0,
+        grades=_grade_counts(s=1, a=2),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.rscore == 60_000
+    assert stats.grades[Grade.S] == 2
+    assert stats.grades[Grade.A] == 1
+    assert updates["rscore"] == 60_000
+    assert updates["s_count"] == 2
+    assert updates["a_count"] == 1
+    assert "max_combo" not in updates
+
+
+def test_apply_weighted_performance_stats_calculates_accuracy_and_pp() -> None:
+    stats = ModeData(
+        tscore=0,
+        rscore=0,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=0,
+        total_hits=0,
+        rank=0,
+        grades=_grade_counts(),
+    )
+
+    updates = score_submission.apply_weighted_performance_stats(
+        stats,
+        [
+            {"pp": 100.0, "acc": 98.0},
+            {"pp": 50.0, "acc": 95.0},
+        ],
+    )
+
+    assert stats.acc == pytest.approx(96.5384615385)
+    assert stats.pp == 148
+    assert updates["acc"] == pytest.approx(96.5384615385)
+    assert updates["pp"] == 148
 
 
 def test_build_submission_charts_formats_osu_client_response() -> None:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -464,9 +464,7 @@ def test_apply_score_stats_updates_max_combo_without_ranked_stats_for_submitted_
     assert "s_count" not in updates
 
 
-def test_apply_score_stats_updates_max_combo_without_ranked_stats_for_loved_map() -> (
-    None
-):
+def test_apply_score_stats_updates_ranked_stats_for_loved_map() -> None:
     score = _score()
     score.bmap.awards_ranked_pp = False
     score.score = 50_000
@@ -481,11 +479,11 @@ def test_apply_score_stats_updates_max_combo_without_ranked_stats_for_loved_map(
     updates = score_submission.apply_score_stats(score, stats)
 
     assert stats.max_combo == 300
-    assert stats.rscore == 1_000
-    assert stats.grades[Grade.S] == 1
+    assert stats.rscore == 51_000
+    assert stats.grades[Grade.S] == 2
     assert updates["max_combo"] == 300
-    assert "rscore" not in updates
-    assert "s_count" not in updates
+    assert updates["rscore"] == 51_000
+    assert updates["s_count"] == 2
 
 
 def test_apply_score_stats_updates_first_best_ranked_score() -> None:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -482,6 +482,37 @@ def test_apply_score_stats_replaces_previous_best_ranked_score_and_grades() -> N
     assert "max_combo" not in updates
 
 
+def test_apply_score_stats_keeps_grade_counts_when_previous_best_grade_matches() -> (
+    None
+):
+    score = _score()
+    score.score = 30_000
+    score.grade = Grade.S
+    previous_best = Score()
+    previous_best.score = 20_000
+    previous_best.grade = Grade.S
+    score.prev_best = previous_best
+    stats = ModeData(
+        tscore=0,
+        rscore=50_000,
+        pp=0,
+        acc=0.0,
+        plays=0,
+        playtime=0,
+        max_combo=100,
+        total_hits=0,
+        rank=0,
+        grades=_grade_counts(s=2),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.rscore == 60_000
+    assert stats.grades[Grade.S] == 2
+    assert updates["rscore"] == 60_000
+    assert "s_count" not in updates
+
+
 def test_apply_weighted_performance_stats_calculates_accuracy_and_pp() -> None:
     stats = ModeData(
         tscore=0,

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -464,7 +464,7 @@ def test_apply_score_stats_updates_max_combo_without_ranked_stats_for_submitted_
     assert "s_count" not in updates
 
 
-def test_apply_score_stats_updates_ranked_stats_for_loved_map() -> None:
+def test_apply_score_stats_skips_ranked_stats_for_loved_map() -> None:
     score = _score()
     score.bmap.awards_ranked_pp = False
     score.score = 50_000
@@ -479,11 +479,11 @@ def test_apply_score_stats_updates_ranked_stats_for_loved_map() -> None:
     updates = score_submission.apply_score_stats(score, stats)
 
     assert stats.max_combo == 300
-    assert stats.rscore == 51_000
-    assert stats.grades[Grade.S] == 2
+    assert stats.rscore == 1_000
+    assert stats.grades[Grade.S] == 1
     assert updates["max_combo"] == 300
-    assert updates["rscore"] == 51_000
-    assert updates["s_count"] == 2
+    assert "rscore" not in updates
+    assert "s_count" not in updates
 
 
 def test_apply_score_stats_updates_first_best_ranked_score() -> None:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -99,6 +99,33 @@ def _grade_counts(
     }
 
 
+def _mode_data(
+    *,
+    tscore: int = 0,
+    rscore: int = 0,
+    pp: int = 0,
+    acc: float = 0.0,
+    plays: int = 0,
+    playtime: int = 0,
+    max_combo: int = 0,
+    total_hits: int = 0,
+    rank: int = 0,
+    grades: dict[Grade, int] | None = None,
+) -> ModeData:
+    return ModeData(
+        tscore=tscore,
+        rscore=rscore,
+        pp=pp,
+        acc=acc,
+        plays=plays,
+        playtime=playtime,
+        max_combo=max_combo,
+        total_hits=total_hits,
+        rank=rank,
+        grades=grades if grades is not None else _grade_counts(),
+    )
+
+
 def _stats() -> tuple[ModeData, ModeData]:
     previous = ModeData(
         tscore=0,
@@ -369,22 +396,14 @@ def test_apply_score_stats_updates_base_stats_for_failed_score() -> None:
     }
 
 
-def test_apply_score_stats_counts_taiko_and_mania_bonus_hits() -> None:
+@pytest.mark.parametrize("mode", [GameMode.VANILLA_TAIKO, GameMode.VANILLA_MANIA])
+def test_apply_score_stats_counts_taiko_and_mania_bonus_hits_by_mode(
+    mode: GameMode,
+) -> None:
     score = _score()
     score.passed = False
-    score.mode = GameMode.VANILLA_TAIKO
-    stats = ModeData(
-        tscore=0,
-        rscore=0,
-        pp=0,
-        acc=0.0,
-        plays=0,
-        playtime=0,
-        max_combo=0,
-        total_hits=0,
-        rank=0,
-        grades=_grade_counts(),
-    )
+    score.mode = mode
+    stats = _mode_data()
 
     updates = score_submission.apply_score_stats(score, stats)
 
@@ -421,6 +440,54 @@ def test_apply_score_stats_skips_leaderboard_stats_without_leaderboard() -> None
     assert "s_count" not in updates
 
 
+def test_apply_score_stats_updates_max_combo_without_ranked_stats_for_submitted_score() -> (
+    None
+):
+    score = _score()
+    score.status = SubmissionStatus.SUBMITTED
+    score.score = 50_000
+    score.max_combo = 300
+    score.grade = Grade.S
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=100,
+        grades=_grade_counts(s=1),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.max_combo == 300
+    assert stats.rscore == 1_000
+    assert stats.grades[Grade.S] == 1
+    assert updates["max_combo"] == 300
+    assert "rscore" not in updates
+    assert "s_count" not in updates
+
+
+def test_apply_score_stats_updates_max_combo_without_ranked_stats_for_loved_map() -> (
+    None
+):
+    score = _score()
+    score.bmap.awards_ranked_pp = False
+    score.score = 50_000
+    score.max_combo = 300
+    score.grade = Grade.S
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=100,
+        grades=_grade_counts(s=1),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.max_combo == 300
+    assert stats.rscore == 1_000
+    assert stats.grades[Grade.S] == 1
+    assert updates["max_combo"] == 300
+    assert "rscore" not in updates
+    assert "s_count" not in updates
+
+
 def test_apply_score_stats_updates_first_best_ranked_score() -> None:
     score = _score()
     score.score = 50_000
@@ -447,6 +514,58 @@ def test_apply_score_stats_updates_first_best_ranked_score() -> None:
     assert updates["max_combo"] == 300
     assert updates["rscore"] == 51_000
     assert updates["s_count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("grade", "update_column"),
+    [
+        (Grade.XH, "xh_count"),
+        (Grade.X, "x_count"),
+        (Grade.SH, "sh_count"),
+        (Grade.S, "s_count"),
+        (Grade.A, "a_count"),
+    ],
+)
+def test_apply_score_stats_updates_first_best_grade_column(
+    grade: Grade,
+    update_column: str,
+) -> None:
+    score = _score()
+    score.score = 50_000
+    score.max_combo = 50
+    score.grade = grade
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=100,
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.rscore == 51_000
+    assert stats.grades[grade] == 1
+    assert updates["rscore"] == 51_000
+    assert updates[update_column] == 1
+    assert "max_combo" not in updates
+
+
+def test_apply_score_stats_updates_first_best_ranked_score_without_b_grade_count() -> (
+    None
+):
+    score = _score()
+    score.score = 50_000
+    score.max_combo = 50
+    score.grade = Grade.B
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=100,
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.rscore == 51_000
+    assert updates["rscore"] == 51_000
+    assert all(f"{grade.name.lower()}_count" not in updates for grade in Grade)
+    assert "max_combo" not in updates
 
 
 def test_apply_score_stats_replaces_previous_best_ranked_score_and_grades() -> None:
@@ -479,6 +598,56 @@ def test_apply_score_stats_replaces_previous_best_ranked_score_and_grades() -> N
     assert updates["rscore"] == 60_000
     assert updates["s_count"] == 2
     assert updates["a_count"] == 1
+    assert "max_combo" not in updates
+
+
+def test_apply_score_stats_replaces_previous_a_best_with_b_grade() -> None:
+    score = _score()
+    score.score = 30_000
+    score.max_combo = 50
+    score.grade = Grade.B
+    previous_best = Score()
+    previous_best.score = 20_000
+    previous_best.grade = Grade.A
+    score.prev_best = previous_best
+    stats = _mode_data(
+        rscore=50_000,
+        max_combo=100,
+        grades=_grade_counts(a=2),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.rscore == 60_000
+    assert stats.grades[Grade.A] == 1
+    assert updates["rscore"] == 60_000
+    assert updates["a_count"] == 1
+    assert "b_count" not in updates
+    assert "max_combo" not in updates
+
+
+def test_apply_score_stats_replaces_previous_b_best_with_a_grade() -> None:
+    score = _score()
+    score.score = 30_000
+    score.max_combo = 50
+    score.grade = Grade.A
+    previous_best = Score()
+    previous_best.score = 20_000
+    previous_best.grade = Grade.B
+    score.prev_best = previous_best
+    stats = _mode_data(
+        rscore=50_000,
+        max_combo=100,
+        grades=_grade_counts(a=2),
+    )
+
+    updates = score_submission.apply_score_stats(score, stats)
+
+    assert stats.rscore == 60_000
+    assert stats.grades[Grade.A] == 3
+    assert updates["rscore"] == 60_000
+    assert updates["a_count"] == 3
+    assert "b_count" not in updates
     assert "max_combo" not in updates
 
 


### PR DESCRIPTION
## Summary
- move score submission stat mutation helpers into `app/usecases/score_submission.py`
- extract ranked score/grade updates and weighted acc/pp calculations for focused unit coverage
- keep database fetch/update and rank recalculation wired in the osu submission endpoint

## Verification
- `uv run --frozen --env-file .env.test pytest tests/unit/usecases/score_submission_test.py -q`
- `make utest`
- `make type-check`
- `make lint`
- `make test`