### PR TITLE
Refactor score submission persistence

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -731,53 +731,7 @@ async def osuSubmitModularSelector(
                     assert announce_chan is not None
                     announce_chan.send(" ".join(ann), sender=score.player, to_self=True)
 
-            # this score is our best score.
-            # update any preexisting personal best
-            # records with SubmissionStatus.SUBMITTED.
-            await app.state.services.database.execute(
-                "UPDATE scores SET status = 1 "
-                "WHERE status = 2 AND map_md5 = :map_md5 "
-                "AND userid = :user_id AND mode = :mode",
-                {
-                    "map_md5": score.bmap.md5,
-                    "user_id": score.player.id,
-                    "mode": score.mode,
-                },
-            )
-
-        score.id = await app.state.services.database.execute(
-            "INSERT INTO scores "
-            "VALUES (NULL, "
-            ":map_md5, :score, :pp, :acc, "
-            ":max_combo, :mods, :n300, :n100, "
-            ":n50, :nmiss, :ngeki, :nkatu, "
-            ":grade, :status, :mode, :play_time, "
-            ":time_elapsed, :client_flags, :user_id, :perfect, "
-            ":checksum)",
-            {
-                "map_md5": score.bmap.md5,
-                "score": score.score,
-                "pp": score.pp,
-                "acc": score.acc,
-                "max_combo": score.max_combo,
-                "mods": score.mods,
-                "n300": score.n300,
-                "n100": score.n100,
-                "n50": score.n50,
-                "nmiss": score.nmiss,
-                "ngeki": score.ngeki,
-                "nkatu": score.nkatu,
-                "grade": score.grade.name,
-                "status": score.status,
-                "mode": score.mode,
-                "play_time": score.server_time,
-                "time_elapsed": score.time_elapsed,
-                "client_flags": score.client_flags,
-                "user_id": score.player.id,
-                "perfect": score.perfect,
-                "checksum": score.client_checksum,
-            },
-        )
+        await score_submission_usecases.persist_submitted_score(score, scores_repo)
 
     if score.passed:
         replay_data = await replay_file.read()

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -49,6 +49,7 @@ from app.constants.clientflags import LastFMFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
 from app.constants.privileges import Privileges
+from app.constants.score_statuses import SubmissionStatus
 from app.logging import Ansi
 from app.logging import log
 from app.objects import models
@@ -57,7 +58,6 @@ from app.objects.beatmap import RankedStatus
 from app.objects.beatmap import ensure_osu_file_is_available
 from app.objects.player import Player
 from app.objects.score import Score
-from app.objects.score import SubmissionStatus
 from app.repositories import clans as clans_repo
 from app.repositories import comments as comments_repo
 from app.repositories import favourites as favourites_repo

--- a/app/commands.py
+++ b/app/commands.py
@@ -44,6 +44,7 @@ from app.constants.mods import SPEED_CHANGING_MODS
 from app.constants.mods import Mods
 from app.constants.privileges import ClanPrivileges
 from app.constants.privileges import Privileges
+from app.constants.score_statuses import SubmissionStatus
 from app.logging import Ansi
 from app.logging import log
 from app.objects.beatmap import Beatmap
@@ -56,7 +57,6 @@ from app.objects.match import MatchWinConditions
 from app.objects.match import SlotStatus
 from app.objects.match import StartingTimers
 from app.objects.player import Player
-from app.objects.score import SubmissionStatus
 from app.repositories import clans as clans_repo
 from app.repositories import logs as logs_repo
 from app.repositories import map_requests as map_requests_repo

--- a/app/constants/__init__.py
+++ b/app/constants/__init__.py
@@ -6,4 +6,3 @@ from . import gamemodes
 from . import mods
 from . import privileges
 from . import regexes
-from . import score_statuses

--- a/app/constants/__init__.py
+++ b/app/constants/__init__.py
@@ -6,3 +6,4 @@ from . import gamemodes
 from . import mods
 from . import privileges
 from . import regexes
+from . import score_statuses

--- a/app/constants/score_statuses.py
+++ b/app/constants/score_statuses.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from enum import unique
+
+from app.utils import escape_enum
+from app.utils import pymysql_encode
+
+
+@unique
+@pymysql_encode(escape_enum)
+class SubmissionStatus(IntEnum):
+    # TODO: make a system more like bancho's?
+    FAILED = 0
+    SUBMITTED = 1
+    BEST = 2
+
+    def __repr__(self) -> str:
+        return {
+            self.FAILED: "Failed",
+            self.SUBMITTED: "Submitted",
+            self.BEST: "Best",
+        }[self]

--- a/app/objects/score.py
+++ b/app/objects/score.py
@@ -14,7 +14,7 @@ import app.utils
 from app.constants.clientflags import ClientFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
-from app.constants.score_statuses import SubmissionStatus as SubmissionStatus
+from app.constants.score_statuses import SubmissionStatus
 from app.objects.beatmap import Beatmap
 from app.repositories import scores as scores_repo
 from app.usecases.performance import ScoreParams
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from app.objects.player import Player
 
 BEATMAPS_PATH = Path.cwd() / ".data/osu"
+__all__ = ("Grade", "Score", "SubmissionStatus")
 
 
 @unique

--- a/app/objects/score.py
+++ b/app/objects/score.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from app.objects.player import Player
 
 BEATMAPS_PATH = Path.cwd() / ".data/osu"
-__all__ = ("Grade", "Score", "SubmissionStatus")
 
 
 @unique

--- a/app/objects/score.py
+++ b/app/objects/score.py
@@ -14,11 +14,10 @@ import app.utils
 from app.constants.clientflags import ClientFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
+from app.constants.score_statuses import SubmissionStatus as SubmissionStatus
 from app.objects.beatmap import Beatmap
 from app.repositories import scores as scores_repo
 from app.usecases.performance import ScoreParams
-from app.utils import escape_enum
-from app.utils import pymysql_encode
 
 if TYPE_CHECKING:
     from app.objects.player import Player
@@ -56,22 +55,6 @@ class Grade(IntEnum):
             "f": Grade.F,
             "n": Grade.N,
         }[s.lower()]
-
-
-@unique
-@pymysql_encode(escape_enum)
-class SubmissionStatus(IntEnum):
-    # TODO: make a system more like bancho's?
-    FAILED = 0
-    SUBMITTED = 1
-    BEST = 2
-
-    def __repr__(self) -> str:
-        return {
-            self.FAILED: "Failed",
-            self.SUBMITTED: "Submitted",
-            self.BEST: "Best",
-        }[self]
 
 
 class Score:

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -19,6 +19,7 @@ from sqlalchemy.dialects.mysql import TINYINT
 import app.state.services
 from app._typing import UNSET
 from app._typing import _UnsetSentinel
+from app.constants.score_statuses import SubmissionStatus
 from app.repositories import Base
 
 
@@ -85,9 +86,6 @@ READ_PARAMS = (
     ScoresTable.perfect,
     ScoresTable.online_checksum,
 )
-
-SUBMITTED_STATUS = 1
-BEST_STATUS = 2
 
 
 class Score(TypedDict):
@@ -178,12 +176,12 @@ async def mark_previous_best_scores_submitted(
     update_stmt = (
         update(ScoresTable)
         .where(
-            ScoresTable.status == BEST_STATUS,
+            ScoresTable.status == SubmissionStatus.BEST.value,
             ScoresTable.map_md5 == map_md5,
             ScoresTable.userid == user_id,
             ScoresTable.mode == mode,
         )
-        .values(status=SUBMITTED_STATUS)
+        .values(status=SubmissionStatus.SUBMITTED.value)
     )
     await app.state.services.database.execute(update_stmt)
 

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -86,6 +86,9 @@ READ_PARAMS = (
     ScoresTable.online_checksum,
 )
 
+SUBMITTED_STATUS = 1
+BEST_STATUS = 2
+
 
 class Score(TypedDict):
     id: int
@@ -164,6 +167,25 @@ async def create(
     _score = await app.state.services.database.fetch_one(select_stmt)
     assert _score is not None
     return cast(Score, _score)
+
+
+async def mark_previous_best_scores_submitted(
+    *,
+    map_md5: str,
+    user_id: int,
+    mode: int,
+) -> None:
+    update_stmt = (
+        update(ScoresTable)
+        .where(
+            ScoresTable.status == BEST_STATUS,
+            ScoresTable.map_md5 == map_md5,
+            ScoresTable.userid == user_id,
+            ScoresTable.mode == mode,
+        )
+        .values(status=SUBMITTED_STATUS)
+    )
+    await app.state.services.database.execute(update_stmt)
 
 
 async def fetch_one(id: int) -> Score | None:

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -8,11 +8,11 @@ from datetime import datetime
 from typing import Any
 from typing import Protocol
 
+from app.constants.score_statuses import SubmissionStatus
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
 from app.objects.score import Grade
 from app.objects.score import Score
-from app.objects.score import SubmissionStatus
 from app.repositories.achievements import Achievement
 from app.repositories.user_achievements import UserAchievement
 

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -4,6 +4,7 @@ import hashlib
 from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 from typing import Protocol
 
@@ -38,6 +39,41 @@ class UserAchievementsService(Protocol):
         user_id: int,
         achievement_id: int,
     ) -> UserAchievement: ...
+
+
+class ScoresRepository(Protocol):
+    async def create(
+        self,
+        map_md5: str,
+        score: int,
+        pp: float,
+        acc: float,
+        max_combo: int,
+        mods: int,
+        n300: int,
+        n100: int,
+        n50: int,
+        nmiss: int,
+        ngeki: int,
+        nkatu: int,
+        grade: str,
+        status: int,
+        mode: int,
+        play_time: datetime,
+        time_elapsed: int,
+        client_flags: int,
+        user_id: int,
+        perfect: int,
+        online_checksum: str,
+    ) -> Mapping[str, Any]: ...
+
+    async def mark_previous_best_scores_submitted(
+        self,
+        *,
+        map_md5: str,
+        user_id: int,
+        mode: int,
+    ) -> None: ...
 
 
 @dataclass(frozen=True)
@@ -138,6 +174,48 @@ def validate_submission_integrity(
         submission_beatmap_md5=submission_beatmap_md5,
         updated_beatmap_hash=updated_beatmap_hash,
     )
+
+
+async def persist_submitted_score(score: Score, scores: ScoresRepository) -> int:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    if score.status == SubmissionStatus.BEST:
+        # this score is our best score.
+        # update any preexisting personal best
+        # records with SubmissionStatus.SUBMITTED.
+        await scores.mark_previous_best_scores_submitted(
+            map_md5=score.bmap.md5,
+            user_id=score.player.id,
+            mode=score.mode.value,
+        )
+
+    created_score = await scores.create(
+        map_md5=score.bmap.md5,
+        score=score.score,
+        pp=score.pp,
+        acc=score.acc,
+        max_combo=score.max_combo,
+        mods=score.mods.value,
+        n300=score.n300,
+        n100=score.n100,
+        n50=score.n50,
+        nmiss=score.nmiss,
+        ngeki=score.ngeki,
+        nkatu=score.nkatu,
+        grade=score.grade.name,
+        status=score.status.value,
+        mode=score.mode.value,
+        play_time=score.server_time,
+        time_elapsed=score.time_elapsed,
+        client_flags=score.client_flags.value,
+        user_id=score.player.id,
+        perfect=int(score.perfect),
+        online_checksum=score.client_checksum,
+    )
+    score_id = int(created_score["id"])
+    score.id = score_id
+    return score_id
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -224,6 +224,97 @@ class _FakeUserAchievements:
         return {"userid": user_id, "achid": achievement_id}
 
 
+class _FakeScoresRepository:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.previous_best_updates: list[dict[str, int | str]] = []
+        self.created_scores: list[dict[str, object]] = []
+
+    async def create(
+        self,
+        **score_fields: object,
+    ) -> dict[str, object]:
+        self.calls.append("create")
+        self.created_scores.append(score_fields)
+        return {"id": 123}
+
+    async def mark_previous_best_scores_submitted(
+        self,
+        *,
+        map_md5: str,
+        user_id: int,
+        mode: int,
+    ) -> None:
+        self.calls.append("mark_previous_best_scores_submitted")
+        self.previous_best_updates.append(
+            {
+                "map_md5": map_md5,
+                "user_id": user_id,
+                "mode": mode,
+            },
+        )
+
+
+async def test_persist_submitted_score_demotes_previous_best_before_creating_score() -> (
+    None
+):
+    score = _score()
+    score.client_checksum = "client-checksum"
+    scores = _FakeScoresRepository()
+
+    score_id = await score_submission.persist_submitted_score(score, scores)
+
+    assert score_id == 123
+    assert score.id == 123
+    assert scores.calls == ["mark_previous_best_scores_submitted", "create"]
+    assert scores.previous_best_updates == [
+        {
+            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
+            "user_id": 6,
+            "mode": GameMode.RELAX_OSU.value,
+        },
+    ]
+    assert scores.created_scores == [
+        {
+            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
+            "score": 26_810,
+            "pp": 10.448,
+            "acc": 81.94,
+            "max_combo": 52,
+            "mods": (Mods.HIDDEN | Mods.RELAX).value,
+            "n300": 83,
+            "n100": 14,
+            "n50": 5,
+            "nmiss": 6,
+            "ngeki": 23,
+            "nkatu": 6,
+            "grade": "C",
+            "status": SubmissionStatus.BEST.value,
+            "mode": GameMode.RELAX_OSU.value,
+            "play_time": datetime(2024, 1, 1, 12, 0, 0),
+            "time_elapsed": 13_358,
+            "client_flags": 0,
+            "user_id": 6,
+            "perfect": 0,
+            "online_checksum": "client-checksum",
+        },
+    ]
+
+
+async def test_persist_submitted_score_creates_non_best_score_without_demoting() -> (
+    None
+):
+    score = _score()
+    score.status = SubmissionStatus.SUBMITTED
+    scores = _FakeScoresRepository()
+
+    await score_submission.persist_submitted_score(score, scores)
+
+    assert scores.calls == ["create"]
+    assert scores.previous_best_updates == []
+    assert scores.created_scores[0]["status"] == SubmissionStatus.SUBMITTED.value
+
+
 def test_parse_unique_id_hashes_md5s_submission_unique_ids() -> None:
     unique_id_hashes = score_submission.parse_unique_id_hashes("unique1|unique2")
 

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -11,13 +11,13 @@ import pytest
 from app.constants.clientflags import ClientFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
+from app.constants.score_statuses import SubmissionStatus
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
 from app.objects.player import OsuStream
 from app.objects.player import OsuVersion
 from app.objects.score import Grade
 from app.objects.score import Score
-from app.objects.score import SubmissionStatus
 from app.usecases import score_submission
 
 


### PR DESCRIPTION
## Summary
- move score insert/demotion orchestration out of the osu submit handler into the score submission usecase
- add a scores repository helper for demoting previous personal bests
- cover best and non-best persistence behavior with focused usecase tests

## Tests
- uv run --frozen --env-file .env.test pytest tests/unit/usecases/score_submission_test.py -q
- make type-check
- make lint
- make utest
- make test