### PR TITLE
Refactor score submission stat persistence

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import random
 import secrets
@@ -43,8 +42,8 @@ import app.settings
 import app.state
 import app.utils
 from app import encryption
-from app._typing import UNSET
 from app.constants import regexes
+from app.constants.beatmap_statuses import RankedStatus
 from app.constants.clientflags import LastFMFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
@@ -54,7 +53,6 @@ from app.logging import Ansi
 from app.logging import log
 from app.objects import models
 from app.objects.beatmap import Beatmap
-from app.objects.beatmap import RankedStatus
 from app.objects.beatmap import ensure_osu_file_is_available
 from app.objects.player import Player
 from app.objects.score import Score
@@ -752,90 +750,21 @@ async def osuSubmitModularSelector(
                 if score.player.is_online:
                     score.player.logout()
 
-    """ Update the user's & beatmap's stats """
+    def publish_user_stats(player: Player) -> None:
+        app.state.sessions.players.enqueue(app.packets.user_stats(player))
 
-    # get the current stats, and take a
-    # shallow copy for the response charts.
-    stats = score.player.stats[score.mode]
-    prev_stats = copy.copy(stats)
-
-    stats_updates = score_submission_usecases.apply_score_stats(score, stats)
-
-    if score.passed and score.bmap.has_leaderboard:
-        # player passed & map is ranked, approved, or loved.
-
-        if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
-            # map is ranked or approved, and it's our (new)
-            # best score on the map. update the player's pp,
-            # acc and global rank.
-
-            # fetch scores sorted by pp for total acc/pp calc
-            # NOTE: we select all plays (and not just top100)
-            # because bonus pp counts the total amount of ranked
-            # scores. I'm aware this scales horribly, and it'll
-            # likely be split into two queries in the future.
-            best_scores = await app.state.services.database.fetch_all(
-                "SELECT s.pp, s.acc FROM scores s "
-                "INNER JOIN maps m ON s.map_md5 = m.md5 "
-                "WHERE s.userid = :user_id AND s.mode = :mode "
-                "AND s.status = 2 AND m.status IN (2, 3) "  # ranked, approved
-                "ORDER BY s.pp DESC",
-                {"user_id": score.player.id, "mode": score.mode},
-            )
-
-            stats_updates.update(
-                score_submission_usecases.apply_weighted_performance_stats(
-                    stats,
-                    best_scores,
-                ),
-            )
-
-            # update global & country ranking
-            stats.rank = await score.player.update_rank(score.mode)
-
-    await stats_repo.partial_update(
-        score.player.id,
-        score.mode.value,
-        plays=stats_updates.get("plays", UNSET),
-        playtime=stats_updates.get("playtime", UNSET),
-        tscore=stats_updates.get("tscore", UNSET),
-        total_hits=stats_updates.get("total_hits", UNSET),
-        max_combo=stats_updates.get("max_combo", UNSET),
-        xh_count=stats_updates.get("xh_count", UNSET),
-        x_count=stats_updates.get("x_count", UNSET),
-        sh_count=stats_updates.get("sh_count", UNSET),
-        s_count=stats_updates.get("s_count", UNSET),
-        a_count=stats_updates.get("a_count", UNSET),
-        rscore=stats_updates.get("rscore", UNSET),
-        acc=stats_updates.get("acc", UNSET),
-        pp=stats_updates.get("pp", UNSET),
+    stats_result = await score_submission_usecases.persist_score_submission_stats(
+        score,
+        stats=stats_repo,
+        scores=scores_repo,
+        maps=maps_repo,
+        publish_user_stats=publish_user_stats,
     )
-
-    if not score.player.restricted:
-        # enqueue new stats info to all other users
-        app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
-
-        # update beatmap with new stats
-        score.bmap.plays += 1
-        if score.passed:
-            score.bmap.passes += 1
-
-        await app.state.services.database.execute(
-            "UPDATE maps SET plays = :plays, passes = :passes WHERE md5 = :map_md5",
-            {
-                "plays": score.bmap.plays,
-                "passes": score.bmap.passes,
-                "map_md5": score.bmap.md5,
-            },
-        )
-
-    # update their recent score
-    score.player.recent_scores[score.mode] = score
 
     response = await score_submission_usecases.build_score_submission_response(
         score=score,
-        previous_stats=prev_stats,
-        current_stats=stats,
+        previous_stats=stats_result.previous_stats,
+        current_stats=stats_result.current_stats,
         domain=app.settings.DOMAIN,
         achievements=achievements_usecases,
         user_achievements=user_achievements_usecases,
@@ -843,7 +772,7 @@ async def osuSubmitModularSelector(
 
     log(
         f"[{score.mode!r}] {score.player} submitted a score! "
-        f"({score.status!r}, {score.pp:,.2f}pp / {stats.pp:,}pp)",
+        f"({score.status!r}, {score.pp:,.2f}pp / {stats_result.current_stats.pp:,}pp)",
         Ansi.LGREEN,
     )
 

--- a/app/commands.py
+++ b/app/commands.py
@@ -39,6 +39,7 @@ import app.state
 import app.usecases.performance
 import app.utils
 from app.constants import regexes
+from app.constants.beatmap_statuses import RankedStatus
 from app.constants.gamemodes import GAMEMODE_REPR_LIST
 from app.constants.mods import SPEED_CHANGING_MODS
 from app.constants.mods import Mods
@@ -48,7 +49,6 @@ from app.constants.score_statuses import SubmissionStatus
 from app.logging import Ansi
 from app.logging import log
 from app.objects.beatmap import Beatmap
-from app.objects.beatmap import RankedStatus
 from app.objects.beatmap import ensure_osu_file_is_available
 from app.objects.match import Match
 from app.objects.match import MatchTeams

--- a/app/constants/beatmap_statuses.py
+++ b/app/constants/beatmap_statuses.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import functools
+from collections import defaultdict
+from collections.abc import Mapping
+from enum import IntEnum
+from enum import unique
+
+from app.utils import escape_enum
+from app.utils import pymysql_encode
+
+
+# for some ungodly reason, different values are used to
+# represent different ranked statuses all throughout osu!
+# This drives me and probably everyone else pretty insane,
+# but we have nothing to do but deal with it B).
+@unique
+@pymysql_encode(escape_enum)
+class RankedStatus(IntEnum):
+    """Server side osu! beatmap ranked statuses.
+    Same as used in osu!'s /web/getscores.php.
+    """
+
+    NotSubmitted = -1
+    Pending = 0
+    UpdateAvailable = 1
+    Ranked = 2
+    Approved = 3
+    Qualified = 4
+    Loved = 5
+
+    def __str__(self) -> str:
+        return {
+            self.NotSubmitted: "Unsubmitted",
+            self.Pending: "Unranked",
+            self.UpdateAvailable: "Outdated",
+            self.Ranked: "Ranked",
+            self.Approved: "Approved",
+            self.Qualified: "Qualified",
+            self.Loved: "Loved",
+        }[self]
+
+    @functools.cached_property
+    def osu_api(self) -> int:
+        """Convert the value to osu!api status."""
+        # XXX: only the ones that exist are mapped.
+        return {
+            self.Pending: 0,
+            self.Ranked: 1,
+            self.Approved: 2,
+            self.Qualified: 3,
+            self.Loved: 4,
+        }[self]
+
+    @classmethod
+    @functools.cache
+    def from_osuapi(cls, osuapi_status: int) -> RankedStatus:
+        """Convert from osu!api status."""
+        mapping: Mapping[int, RankedStatus] = defaultdict(
+            lambda: cls.UpdateAvailable,
+            {
+                -2: cls.Pending,  # graveyard
+                -1: cls.Pending,  # wip
+                0: cls.Pending,
+                1: cls.Ranked,
+                2: cls.Approved,
+                3: cls.Qualified,
+                4: cls.Loved,
+            },
+        )
+        return mapping[osuapi_status]
+
+    @classmethod
+    @functools.cache
+    def from_osudirect(cls, osudirect_status: int) -> RankedStatus:
+        """Convert from osu!direct status."""
+        mapping: Mapping[int, RankedStatus] = defaultdict(
+            lambda: cls.UpdateAvailable,
+            {
+                0: cls.Ranked,
+                2: cls.Pending,
+                3: cls.Qualified,
+                # 4: all ranked statuses lol
+                5: cls.Pending,  # graveyard
+                7: cls.Ranked,  # played before
+                8: cls.Loved,
+            },
+        )
+        return mapping[osudirect_status]
+
+    @classmethod
+    @functools.cache
+    def from_str(cls, status_str: str) -> RankedStatus:
+        """Convert from string value."""  # could perhaps have `'unranked': cls.Pending`?
+        mapping: Mapping[str, RankedStatus] = defaultdict(
+            lambda: cls.UpdateAvailable,
+            {
+                "pending": cls.Pending,
+                "ranked": cls.Ranked,
+                "approved": cls.Approved,
+                "qualified": cls.Qualified,
+                "loved": cls.Loved,
+            },
+        )
+        return mapping[status_str]

--- a/app/objects/beatmap.py
+++ b/app/objects/beatmap.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 import functools
 import hashlib
-from collections import defaultdict
-from collections.abc import Mapping
 from datetime import datetime
 from datetime import timedelta
-from enum import IntEnum
-from enum import unique
 from pathlib import Path
 from typing import Any
 from typing import TypedDict
@@ -19,12 +15,11 @@ from tenacity.stop import stop_after_attempt
 import app.settings
 import app.state
 import app.utils
+from app.constants.beatmap_statuses import RankedStatus
 from app.constants.gamemodes import GameMode
 from app.logging import Ansi
 from app.logging import log
 from app.repositories import maps as maps_repo
-from app.utils import escape_enum
-from app.utils import pymysql_encode
 
 # from dataclasses import dataclass
 
@@ -117,103 +112,6 @@ async def ensure_osu_file_is_available(
 
     write_osu_file_to_disk(beatmap_id, latest_osu_file)
     return True
-
-
-# for some ungodly reason, different values are used to
-# represent different ranked statuses all throughout osu!
-# This drives me and probably everyone else pretty insane,
-# but we have nothing to do but deal with it B).
-
-
-@unique
-@pymysql_encode(escape_enum)
-class RankedStatus(IntEnum):
-    """Server side osu! beatmap ranked statuses.
-    Same as used in osu!'s /web/getscores.php.
-    """
-
-    NotSubmitted = -1
-    Pending = 0
-    UpdateAvailable = 1
-    Ranked = 2
-    Approved = 3
-    Qualified = 4
-    Loved = 5
-
-    def __str__(self) -> str:
-        return {
-            self.NotSubmitted: "Unsubmitted",
-            self.Pending: "Unranked",
-            self.UpdateAvailable: "Outdated",
-            self.Ranked: "Ranked",
-            self.Approved: "Approved",
-            self.Qualified: "Qualified",
-            self.Loved: "Loved",
-        }[self]
-
-    @functools.cached_property
-    def osu_api(self) -> int:
-        """Convert the value to osu!api status."""
-        # XXX: only the ones that exist are mapped.
-        return {
-            self.Pending: 0,
-            self.Ranked: 1,
-            self.Approved: 2,
-            self.Qualified: 3,
-            self.Loved: 4,
-        }[self]
-
-    @classmethod
-    @functools.cache
-    def from_osuapi(cls, osuapi_status: int) -> RankedStatus:
-        """Convert from osu!api status."""
-        mapping: Mapping[int, RankedStatus] = defaultdict(
-            lambda: cls.UpdateAvailable,
-            {
-                -2: cls.Pending,  # graveyard
-                -1: cls.Pending,  # wip
-                0: cls.Pending,
-                1: cls.Ranked,
-                2: cls.Approved,
-                3: cls.Qualified,
-                4: cls.Loved,
-            },
-        )
-        return mapping[osuapi_status]
-
-    @classmethod
-    @functools.cache
-    def from_osudirect(cls, osudirect_status: int) -> RankedStatus:
-        """Convert from osu!direct status."""
-        mapping: Mapping[int, RankedStatus] = defaultdict(
-            lambda: cls.UpdateAvailable,
-            {
-                0: cls.Ranked,
-                2: cls.Pending,
-                3: cls.Qualified,
-                # 4: all ranked statuses lol
-                5: cls.Pending,  # graveyard
-                7: cls.Ranked,  # played before
-                8: cls.Loved,
-            },
-        )
-        return mapping[osudirect_status]
-
-    @classmethod
-    @functools.cache
-    def from_str(cls, status_str: str) -> RankedStatus:
-        """Convert from string value."""  # could perhaps have `'unranked': cls.Pending`?
-        mapping: Mapping[str, RankedStatus] = defaultdict(
-            lambda: cls.UpdateAvailable,
-            {
-                "pending": cls.Pending,
-                "ranked": cls.Ranked,
-                "approved": cls.Approved,
-                "qualified": cls.Qualified,
-                "loved": cls.Loved,
-            },
-        )
-        return mapping[status_str]
 
 
 # @dataclass

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
 from typing import TypedDict
 from typing import cast
@@ -19,8 +20,10 @@ from sqlalchemy.dialects.mysql import TINYINT
 import app.state.services
 from app._typing import UNSET
 from app._typing import _UnsetSentinel
+from app.constants.beatmap_statuses import RankedStatus
 from app.constants.score_statuses import SubmissionStatus
 from app.repositories import Base
+from app.repositories.maps import MapsTable
 
 
 class ScoresTable(Base):
@@ -184,6 +187,32 @@ async def mark_previous_best_scores_submitted(
         .values(status=SubmissionStatus.SUBMITTED.value)
     )
     await app.state.services.database.execute(update_stmt)
+
+
+async def fetch_weighted_best_performances(
+    *,
+    user_id: int,
+    mode: int,
+) -> list[Mapping[str, float]]:
+    select_stmt = (
+        select(ScoresTable.pp, ScoresTable.acc)
+        .join(MapsTable, ScoresTable.map_md5 == MapsTable.md5)
+        .where(
+            ScoresTable.userid == user_id,
+            ScoresTable.mode == mode,
+            ScoresTable.status == SubmissionStatus.BEST.value,
+            MapsTable.status.in_(
+                (
+                    RankedStatus.Ranked.value,
+                    RankedStatus.Approved.value,
+                ),
+            ),
+        )
+        .order_by(ScoresTable.pp.desc())
+    )
+
+    scores = await app.state.services.database.fetch_all(select_stmt)
+    return cast(list[Mapping[str, float]], scores)
 
 
 async def fetch_one(id: int) -> Score | None:

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import copy
 import hashlib
+from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -8,9 +10,12 @@ from datetime import datetime
 from typing import Any
 from typing import Protocol
 
+from app._typing import UNSET
+from app._typing import _UnsetSentinel
 from app.constants.score_statuses import SubmissionStatus
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
+from app.objects.player import Player
 from app.objects.score import Grade
 from app.objects.score import Score
 from app.repositories.achievements import Achievement
@@ -75,11 +80,56 @@ class ScoresRepository(Protocol):
         mode: int,
     ) -> None: ...
 
+    async def fetch_weighted_best_performances(
+        self,
+        *,
+        user_id: int,
+        mode: int,
+    ) -> Sequence[BestScorePerformance]: ...
+
+
+class StatsRepository(Protocol):
+    async def partial_update(
+        self,
+        player_id: int,
+        mode: int,
+        tscore: int | _UnsetSentinel = UNSET,
+        rscore: int | _UnsetSentinel = UNSET,
+        pp: int | _UnsetSentinel = UNSET,
+        plays: int | _UnsetSentinel = UNSET,
+        playtime: int | _UnsetSentinel = UNSET,
+        acc: float | _UnsetSentinel = UNSET,
+        max_combo: int | _UnsetSentinel = UNSET,
+        total_hits: int | _UnsetSentinel = UNSET,
+        replay_views: int | _UnsetSentinel = UNSET,
+        xh_count: int | _UnsetSentinel = UNSET,
+        x_count: int | _UnsetSentinel = UNSET,
+        sh_count: int | _UnsetSentinel = UNSET,
+        s_count: int | _UnsetSentinel = UNSET,
+        a_count: int | _UnsetSentinel = UNSET,
+    ) -> Mapping[str, Any] | None: ...
+
+
+class MapsRepository(Protocol):
+    async def partial_update(
+        self,
+        id: int,
+        *,
+        plays: int | _UnsetSentinel = UNSET,
+        passes: int | _UnsetSentinel = UNSET,
+    ) -> Mapping[str, Any] | None: ...
+
 
 @dataclass(frozen=True)
 class UniqueIdHashes:
     unique_id1_md5: str
     unique_id2_md5: str
+
+
+@dataclass(frozen=True)
+class ScoreStatsPersistenceResult:
+    previous_stats: ModeData
+    current_stats: ModeData
 
 
 def parse_unique_id_hashes(unique_ids: str) -> UniqueIdHashes:
@@ -327,6 +377,94 @@ def apply_weighted_performance_stats(
         "acc": stats.acc,
         "pp": stats.pp,
     }
+
+
+async def persist_score_submission_stats(
+    score: Score,
+    *,
+    stats: StatsRepository,
+    scores: ScoresRepository,
+    maps: MapsRepository,
+    publish_user_stats: Callable[[Player], None],
+) -> ScoreStatsPersistenceResult:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    # get the current stats, and take a
+    # shallow copy for the response charts.
+    current_stats = score.player.stats[score.mode]
+    previous_stats = copy.copy(current_stats)
+
+    stats_updates = apply_score_stats(score, current_stats)
+
+    if score.passed and score.bmap.has_leaderboard:
+        # player passed & map is ranked, approved, or loved.
+
+        if score.bmap.awards_ranked_pp and score.status == SubmissionStatus.BEST:
+            # map is ranked or approved, and it's our (new)
+            # best score on the map. update the player's pp,
+            # acc and global rank.
+
+            # fetch scores sorted by pp for total acc/pp calc
+            # NOTE: we select all plays (and not just top100)
+            # because bonus pp counts the total amount of ranked
+            # scores. I'm aware this scales horribly, and it'll
+            # likely be split into two queries in the future.
+            best_scores = await scores.fetch_weighted_best_performances(
+                user_id=score.player.id,
+                mode=score.mode.value,
+            )
+
+            stats_updates.update(
+                apply_weighted_performance_stats(
+                    current_stats,
+                    best_scores,
+                ),
+            )
+
+            # update global & country ranking
+            current_stats.rank = await score.player.update_rank(score.mode)
+
+    await stats.partial_update(
+        score.player.id,
+        score.mode.value,
+        plays=stats_updates.get("plays", UNSET),
+        playtime=stats_updates.get("playtime", UNSET),
+        tscore=stats_updates.get("tscore", UNSET),
+        total_hits=stats_updates.get("total_hits", UNSET),
+        max_combo=stats_updates.get("max_combo", UNSET),
+        xh_count=stats_updates.get("xh_count", UNSET),
+        x_count=stats_updates.get("x_count", UNSET),
+        sh_count=stats_updates.get("sh_count", UNSET),
+        s_count=stats_updates.get("s_count", UNSET),
+        a_count=stats_updates.get("a_count", UNSET),
+        rscore=stats_updates.get("rscore", UNSET),
+        acc=stats_updates.get("acc", UNSET),
+        pp=stats_updates.get("pp", UNSET),
+    )
+
+    if not score.player.restricted:
+        # enqueue new stats info to all other users
+        publish_user_stats(score.player)
+
+        # update beatmap with new stats
+        score.bmap.plays += 1
+        if score.passed:
+            score.bmap.passes += 1
+
+        await maps.partial_update(
+            score.bmap.id,
+            plays=score.bmap.plays,
+            passes=score.bmap.passes,
+        )
+
+    # update their recent score
+    score.player.recent_scores[score.mode] = score
+
+    return ScoreStatsPersistenceResult(
+        previous_stats=previous_stats,
+        current_stats=current_stats,
+    )
 
 
 def chart_entry(

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app._typing import UNSET
 from app.constants.clientflags import ClientFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
@@ -255,6 +256,103 @@ class _FakeScoresRepository:
         )
 
 
+class _FakeScorePerformanceRepository:
+    def __init__(
+        self,
+        best_scores: list[dict[str, float]] | None = None,
+    ) -> None:
+        self.best_scores = best_scores if best_scores is not None else []
+        self.fetches: list[dict[str, int]] = []
+
+    async def fetch_weighted_best_performances(
+        self,
+        *,
+        user_id: int,
+        mode: int,
+    ) -> list[dict[str, float]]:
+        self.fetches.append({"user_id": user_id, "mode": mode})
+        return self.best_scores
+
+
+class _FailingScorePerformanceRepository:
+    async def fetch_weighted_best_performances(
+        self,
+        *,
+        user_id: int,
+        mode: int,
+    ) -> list[dict[str, float]]:
+        raise AssertionError("weighted best scores should not be fetched")
+
+
+class _FakeStatsRepository:
+    def __init__(self) -> None:
+        self.partial_updates: list[dict[str, object]] = []
+
+    async def partial_update(
+        self,
+        player_id: int,
+        mode: int,
+        **updates: object,
+    ) -> dict[str, object] | None:
+        self.partial_updates.append(
+            {
+                "player_id": player_id,
+                "mode": mode,
+                "updates": {
+                    key: value for key, value in updates.items() if value is not UNSET
+                },
+            },
+        )
+        return None
+
+
+class _FakeMapsRepository:
+    def __init__(self) -> None:
+        self.partial_updates: list[dict[str, object]] = []
+
+    async def partial_update(
+        self,
+        id: int,
+        **updates: object,
+    ) -> dict[str, object] | None:
+        self.partial_updates.append(
+            {
+                "id": id,
+                "updates": {
+                    key: value for key, value in updates.items() if value is not UNSET
+                },
+            },
+        )
+        return None
+
+
+class _FakeUserStatsPublisher:
+    def __init__(self) -> None:
+        self.published_players: list[object] = []
+
+    def __call__(self, player: object) -> None:
+        self.published_players.append(player)
+
+
+class _FakePlayer:
+    def __init__(
+        self,
+        *,
+        stats: ModeData,
+        restricted: bool = False,
+    ) -> None:
+        self.id = 6
+        self.name = "test-user"
+        self.restricted = restricted
+        self.stats = {GameMode.RELAX_OSU: stats}
+        self.recent_scores: dict[GameMode, Score] = {}
+        self.updated_rank_modes: list[GameMode] = []
+
+    async def update_rank(self, mode: GameMode) -> int:
+        self.updated_rank_modes.append(mode)
+        return 7
+
+
 async def test_persist_submitted_score_demotes_previous_best_before_creating_score() -> (
     None
 ):
@@ -313,6 +411,180 @@ async def test_persist_submitted_score_creates_non_best_score_without_demoting()
     assert scores.calls == ["create"]
     assert scores.previous_best_updates == []
     assert scores.created_scores[0]["status"] == SubmissionStatus.SUBMITTED.value
+
+
+async def test_persist_score_submission_stats_updates_ranked_best_score_side_effects() -> (
+    None
+):
+    score = _score()
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=40,
+        grades=_grade_counts(),
+    )
+    player = _FakePlayer(stats=stats)
+    score.player = player
+    score.bmap.plays = 1
+    score.bmap.passes = 1
+    stats_repo = _FakeStatsRepository()
+    scores_repo = _FakeScorePerformanceRepository(
+        best_scores=[
+            {"pp": 100.0, "acc": 98.0},
+            {"pp": 50.0, "acc": 95.0},
+        ],
+    )
+    maps_repo = _FakeMapsRepository()
+    publish_user_stats = _FakeUserStatsPublisher()
+
+    result = await score_submission.persist_score_submission_stats(
+        score,
+        stats=stats_repo,
+        scores=scores_repo,
+        maps=maps_repo,
+        publish_user_stats=publish_user_stats,
+    )
+
+    assert result.previous_stats.plays == 0
+    assert result.current_stats.plays == 1
+    assert result.current_stats.playtime == 13
+    assert result.current_stats.tscore == 26_810
+    assert result.current_stats.total_hits == 102
+    assert result.current_stats.max_combo == 52
+    assert result.current_stats.rscore == 27_810
+    assert result.current_stats.acc == pytest.approx(96.5384615385)
+    assert result.current_stats.pp == 148
+    assert result.current_stats.rank == 7
+    assert player.updated_rank_modes == [GameMode.RELAX_OSU]
+    assert scores_repo.fetches == [
+        {
+            "user_id": 6,
+            "mode": GameMode.RELAX_OSU.value,
+        },
+    ]
+    assert stats_repo.partial_updates == [
+        {
+            "player_id": 6,
+            "mode": GameMode.RELAX_OSU.value,
+            "updates": {
+                "plays": 1,
+                "playtime": 13,
+                "tscore": 26_810,
+                "total_hits": 102,
+                "max_combo": 52,
+                "rscore": 27_810,
+                "acc": pytest.approx(96.5384615385),
+                "pp": 148,
+            },
+        },
+    ]
+    assert publish_user_stats.published_players == [player]
+    assert score.bmap.plays == 2
+    assert score.bmap.passes == 2
+    assert maps_repo.partial_updates == [
+        {
+            "id": 315,
+            "updates": {
+                "plays": 2,
+                "passes": 2,
+            },
+        },
+    ]
+    assert player.recent_scores[GameMode.RELAX_OSU] is score
+
+
+async def test_persist_score_submission_stats_updates_failed_score_without_weighted_stats() -> (
+    None
+):
+    score = _score()
+    score.passed = False
+    score.status = SubmissionStatus.FAILED
+    stats = _mode_data(
+        plays=2,
+        playtime=5,
+        tscore=10,
+        total_hits=7,
+    )
+    player = _FakePlayer(stats=stats)
+    score.player = player
+    score.bmap.plays = 1
+    score.bmap.passes = 1
+    stats_repo = _FakeStatsRepository()
+    maps_repo = _FakeMapsRepository()
+    publish_user_stats = _FakeUserStatsPublisher()
+
+    result = await score_submission.persist_score_submission_stats(
+        score,
+        stats=stats_repo,
+        scores=_FailingScorePerformanceRepository(),
+        maps=maps_repo,
+        publish_user_stats=publish_user_stats,
+    )
+
+    assert result.previous_stats.plays == 2
+    assert result.current_stats.plays == 3
+    assert result.current_stats.playtime == 18
+    assert result.current_stats.tscore == 26_820
+    assert result.current_stats.total_hits == 109
+    assert player.updated_rank_modes == []
+    assert stats_repo.partial_updates == [
+        {
+            "player_id": 6,
+            "mode": GameMode.RELAX_OSU.value,
+            "updates": {
+                "plays": 3,
+                "playtime": 18,
+                "tscore": 26_820,
+                "total_hits": 109,
+            },
+        },
+    ]
+    assert publish_user_stats.published_players == [player]
+    assert score.bmap.plays == 2
+    assert score.bmap.passes == 1
+    assert maps_repo.partial_updates == [
+        {
+            "id": 315,
+            "updates": {
+                "plays": 2,
+                "passes": 1,
+            },
+        },
+    ]
+    assert player.recent_scores[GameMode.RELAX_OSU] is score
+
+
+async def test_persist_score_submission_stats_skips_public_side_effects_for_restricted_player() -> (
+    None
+):
+    score = _score()
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=40,
+        grades=_grade_counts(),
+    )
+    player = _FakePlayer(stats=stats, restricted=True)
+    score.player = player
+    score.bmap.awards_ranked_pp = False
+    score.bmap.plays = 1
+    score.bmap.passes = 1
+    stats_repo = _FakeStatsRepository()
+    maps_repo = _FakeMapsRepository()
+    publish_user_stats = _FakeUserStatsPublisher()
+
+    await score_submission.persist_score_submission_stats(
+        score,
+        stats=stats_repo,
+        scores=_FakeScorePerformanceRepository(),
+        maps=maps_repo,
+        publish_user_stats=publish_user_stats,
+    )
+
+    assert stats_repo.partial_updates != []
+    assert publish_user_stats.published_players == []
+    assert score.bmap.plays == 1
+    assert score.bmap.passes == 1
+    assert maps_repo.partial_updates == []
+    assert player.recent_scores[GameMode.RELAX_OSU] is score
 
 
 def test_parse_unique_id_hashes_md5s_submission_unique_ids() -> None:


### PR DESCRIPTION
## Summary
- move score submission stat persistence and related side effects into the score submission usecase
- add repository helper for weighted best-score performance reads
- move RankedStatus to constants so repositories do not import object modules for status values
- cover ranked best, failed score, and restricted-player stat persistence branches

## Tests
- uv run --frozen --env-file .env.test pytest tests/unit/usecases/score_submission_test.py -q
- uv run --frozen --env-file .env.test pytest tests/unit/usecases/score_submission_test.py tests/unit/commands_test.py tests/unit/api/domains/osu_test.py -q
- make type-check
- make lint
- make utest
- make test