### PR TITLE
Refactor score submission side effects

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -670,27 +670,19 @@ async def osuSubmitModularSelector(
         if app.state.services.datadog:
             app.state.services.datadog.increment("bancho.submitted_scores")  # type: ignore[no-untyped-call]
 
+        def send_personal_best_notification(player: Player, message: str) -> None:
+            player.enqueue(app.packets.notification(message))
+
         if score.status == SubmissionStatus.BEST:
             if app.state.services.datadog:
                 app.state.services.datadog.increment("bancho.submitted_scores_best")  # type: ignore[no-untyped-call]
 
-            if score.bmap.has_leaderboard:
-                if score.bmap.status == RankedStatus.Loved and score.mode in (
-                    GameMode.VANILLA_OSU,
-                    GameMode.VANILLA_TAIKO,
-                    GameMode.VANILLA_CATCH,
-                    GameMode.VANILLA_MANIA,
-                ):
-                    performance = f"{score.score:,} score"
-                else:
-                    performance = f"{score.pp:,.2f}pp"
+            performance = score_submission_usecases.notify_personal_best(
+                score,
+                send_notification=send_personal_best_notification,
+            )
 
-                score.player.enqueue(
-                    app.packets.notification(
-                        f"You achieved #{score.rank}! ({performance})",
-                    ),
-                )
-
+            if performance is not None:
                 if score.rank == 1 and not score.player.restricted:
                     announce_chan = app.state.sessions.channels.get_by_name("#announce")
 

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -731,24 +731,16 @@ async def osuSubmitModularSelector(
 
         await score_submission_usecases.persist_submitted_score(score, scores_repo)
 
-    if score.passed:
-        replay_data = await replay_file.read()
+    def log_missing_replay(message: str) -> None:
+        log(message, Ansi.LRED)
 
-        MIN_REPLAY_SIZE = 24
-
-        if len(replay_data) >= MIN_REPLAY_SIZE:
-            replay_disk_file = REPLAYS_PATH / f"{score.id}.osr"
-            replay_disk_file.write_bytes(replay_data)
-        else:
-            log(f"{score.player} submitted a score without a replay!", Ansi.LRED)
-
-            if not score.player.restricted:
-                await score.player.restrict(
-                    admin=app.state.sessions.bot,
-                    reason="submitted score with no replay",
-                )
-                if score.player.is_online:
-                    score.player.logout()
+    await score_submission_usecases.save_replay_file(
+        score,
+        replay_file=replay_file,
+        replays_path=REPLAYS_PATH,
+        restriction_admin=app.state.sessions.bot,
+        log_missing_replay=log_missing_replay,
+    )
 
     def publish_user_stats(player: Player) -> None:
         app.state.sessions.players.enqueue(app.packets.user_stats(player))

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -677,7 +677,7 @@ async def osuSubmitModularSelector(
             if app.state.services.datadog:
                 app.state.services.datadog.increment("bancho.submitted_scores_best")  # type: ignore[no-untyped-call]
 
-            score_submission_usecases.notify_personal_best(
+            score_submission_usecases.notify_score_submitter_of_personal_best(
                 score,
                 send_notification=send_personal_best_notification,
             )

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -677,49 +677,18 @@ async def osuSubmitModularSelector(
             if app.state.services.datadog:
                 app.state.services.datadog.increment("bancho.submitted_scores_best")  # type: ignore[no-untyped-call]
 
-            performance = score_submission_usecases.notify_personal_best(
+            score_submission_usecases.notify_personal_best(
                 score,
                 send_notification=send_personal_best_notification,
             )
 
-            if performance is not None:
-                if score.rank == 1 and not score.player.restricted:
-                    announce_chan = app.state.sessions.channels.get_by_name("#announce")
-
-                    ann = [
-                        f"\x01ACTION achieved #1 on {score.bmap.embed}",
-                        f"with {score.acc:.2f}% for {performance}.",
-                    ]
-
-                    if score.mods:
-                        ann.insert(1, f"+{score.mods!r}")
-
-                    scoring_metric = (
-                        "pp" if score.mode >= GameMode.RELAX_OSU else "score"
-                    )
-
-                    # If there was previously a score on the map, add old #1.
-                    prev_n1 = await app.state.services.database.fetch_one(
-                        "SELECT u.id, name FROM users u "
-                        "INNER JOIN scores s ON u.id = s.userid "
-                        "WHERE s.map_md5 = :map_md5 AND s.mode = :mode "
-                        "AND s.status = 2 AND u.priv & 1 "
-                        f"ORDER BY s.{scoring_metric} DESC LIMIT 1",
-                        {"map_md5": score.bmap.md5, "mode": score.mode},
-                    )
-
-                    if prev_n1:
-                        if score.player.id != prev_n1["id"]:
-                            ann.append(
-                                f"(Previous #1: [https://{app.settings.DOMAIN}/u/"
-                                "{id} {name}])".format(
-                                    id=prev_n1["id"],
-                                    name=prev_n1["name"],
-                                ),
-                            )
-
-                    assert announce_chan is not None
-                    announce_chan.send(" ".join(ann), sender=score.player, to_self=True)
+            announce_chan = app.state.sessions.channels.get_by_name("#announce")
+            await score_submission_usecases.announce_first_place(
+                score,
+                scores=scores_repo,
+                announce_channel=announce_chan,
+                domain=app.settings.DOMAIN,
+            )
 
         await score_submission_usecases.persist_submitted_score(score, scores_repo)
 

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime
+from typing import Literal
 from typing import TypedDict
 from typing import cast
 
@@ -21,6 +22,7 @@ import app.state.services
 from app._typing import UNSET
 from app._typing import _UnsetSentinel
 from app.constants.beatmap_statuses import RankedStatus
+from app.constants.privileges import Privileges
 from app.constants.score_statuses import SubmissionStatus
 from app.repositories import Base
 from app.repositories.maps import MapsTable
@@ -90,6 +92,8 @@ READ_PARAMS = (
     ScoresTable.online_checksum,
 )
 
+FirstPlaceScoringMetric = Literal["score", "pp"]
+
 
 class Score(TypedDict):
     id: int
@@ -114,6 +118,11 @@ class Score(TypedDict):
     userid: int
     perfect: int
     online_checksum: str
+
+
+class PreviousFirstPlace(TypedDict):
+    id: int
+    name: str
 
 
 async def create(
@@ -213,6 +222,28 @@ async def fetch_weighted_best_performances(
 
     scores = await app.state.services.database.fetch_all(select_stmt)
     return cast(list[Mapping[str, float]], scores)
+
+
+async def fetch_previous_first_place(
+    *,
+    map_md5: str,
+    mode: int,
+    scoring_metric: FirstPlaceScoringMetric,
+) -> PreviousFirstPlace | None:
+    previous_first_place = await app.state.services.database.fetch_one(
+        "SELECT u.id, name FROM users u "
+        "INNER JOIN scores s ON u.id = s.userid "
+        "WHERE s.map_md5 = :map_md5 AND s.mode = :mode "
+        "AND s.status = :status AND u.priv & :unrestricted_priv "
+        f"ORDER BY s.{scoring_metric} DESC LIMIT 1",
+        {
+            "map_md5": map_md5,
+            "mode": mode,
+            "status": SubmissionStatus.BEST.value,
+            "unrestricted_priv": Privileges.UNRESTRICTED.value,
+        },
+    )
+    return cast(PreviousFirstPlace | None, previous_first_place)
 
 
 async def fetch_one(id: int) -> Score | None:

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from typing import Literal
 from typing import Protocol
 
 from app._typing import UNSET
@@ -26,6 +27,7 @@ from app.repositories.user_achievements import UserAchievement
 
 StatsUpdates = dict[str, Any]
 BestScorePerformance = Mapping[str, float]
+FirstPlaceScoringMetric = Literal["score", "pp"]
 MIN_REPLAY_SIZE = 24
 VANILLA_GAME_MODES = (
     GameMode.VANILLA_OSU,
@@ -58,6 +60,10 @@ class UserAchievementsService(Protocol):
 
 class ReplayFile(Protocol):
     async def read(self) -> bytes: ...
+
+
+class AnnouncementChannel(Protocol):
+    def send(self, msg: str, sender: Player, to_self: bool = False) -> None: ...
 
 
 class ScoresRepository(Protocol):
@@ -100,6 +106,14 @@ class ScoresRepository(Protocol):
         user_id: int,
         mode: int,
     ) -> Sequence[BestScorePerformance]: ...
+
+    async def fetch_previous_first_place(
+        self,
+        *,
+        map_md5: str,
+        mode: int,
+        scoring_metric: FirstPlaceScoringMetric,
+    ) -> Mapping[str, Any] | None: ...
 
 
 class StatsRepository(Protocol):
@@ -343,6 +357,59 @@ def notify_personal_best(
         f"You achieved #{score.rank}! ({performance})",
     )
     return performance
+
+
+def first_place_scoring_metric(score: Score) -> FirstPlaceScoringMetric:
+    return "pp" if score.mode >= GameMode.RELAX_OSU else "score"
+
+
+async def announce_first_place(
+    score: Score,
+    *,
+    scores: ScoresRepository,
+    announce_channel: AnnouncementChannel | None,
+    domain: str,
+) -> None:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    if score.status != SubmissionStatus.BEST:
+        return
+
+    if not score.bmap.has_leaderboard:
+        return
+
+    if score.rank != 1:
+        return
+
+    if score.player.restricted:
+        return
+
+    performance = format_score_submission_performance(score)
+    ann = [
+        f"\x01ACTION achieved #1 on {score.bmap.embed}",
+        f"with {score.acc:.2f}% for {performance}.",
+    ]
+
+    if score.mods:
+        ann.insert(1, f"+{score.mods!r}")
+
+    # If there was previously a score on the map, add old #1.
+    prev_n1 = await scores.fetch_previous_first_place(
+        map_md5=score.bmap.md5,
+        mode=score.mode.value,
+        scoring_metric=first_place_scoring_metric(score),
+    )
+
+    if prev_n1:
+        if score.player.id != prev_n1["id"]:
+            ann.append(
+                f"(Previous #1: [https://{domain}/u/{prev_n1['id']} "
+                f"{prev_n1['name']}])",
+            )
+
+    assert announce_channel is not None
+    announce_channel.send(" ".join(ann), sender=score.player, to_self=True)
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 from typing import Protocol
 
@@ -23,6 +24,7 @@ from app.repositories.user_achievements import UserAchievement
 
 StatsUpdates = dict[str, Any]
 BestScorePerformance = Mapping[str, float]
+MIN_REPLAY_SIZE = 24
 GRADE_STATS_COLUMNS = {
     Grade.XH: "xh_count",
     Grade.X: "x_count",
@@ -44,6 +46,10 @@ class UserAchievementsService(Protocol):
         user_id: int,
         achievement_id: int,
     ) -> UserAchievement: ...
+
+
+class ReplayFile(Protocol):
+    async def read(self) -> bytes: ...
 
 
 class ScoresRepository(Protocol):
@@ -266,6 +272,38 @@ async def persist_submitted_score(score: Score, scores: ScoresRepository) -> int
     score_id = int(created_score["id"])
     score.id = score_id
     return score_id
+
+
+async def save_replay_file(
+    score: Score,
+    *,
+    replay_file: ReplayFile,
+    replays_path: Path,
+    restriction_admin: Player,
+    log_missing_replay: Callable[[str], None],
+) -> None:
+    assert score.player is not None
+
+    if not score.passed:
+        return
+
+    replay_data = await replay_file.read()
+
+    if len(replay_data) >= MIN_REPLAY_SIZE:
+        assert score.id is not None
+        replay_disk_file = replays_path / f"{score.id}.osr"
+        replay_disk_file.write_bytes(replay_data)
+        return
+
+    log_missing_replay(f"{score.player} submitted a score without a replay!")
+
+    if not score.player.restricted:
+        await score.player.restrict(
+            admin=restriction_admin,
+            reason="submitted score with no replay",
+        )
+        if score.player.is_online:
+            score.player.logout()
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -337,7 +337,7 @@ def format_score_submission_performance(score: Score) -> str:
     return f"{score.pp:,.2f}pp"
 
 
-def notify_personal_best(
+def notify_score_submitter_of_personal_best(
     score: Score,
     *,
     send_notification: Callable[[Player, str], None],

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -13,6 +13,8 @@ from typing import Protocol
 
 from app._typing import UNSET
 from app._typing import _UnsetSentinel
+from app.constants.beatmap_statuses import RankedStatus
+from app.constants.gamemodes import GameMode
 from app.constants.score_statuses import SubmissionStatus
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
@@ -25,6 +27,12 @@ from app.repositories.user_achievements import UserAchievement
 StatsUpdates = dict[str, Any]
 BestScorePerformance = Mapping[str, float]
 MIN_REPLAY_SIZE = 24
+VANILLA_GAME_MODES = (
+    GameMode.VANILLA_OSU,
+    GameMode.VANILLA_TAIKO,
+    GameMode.VANILLA_CATCH,
+    GameMode.VANILLA_MANIA,
+)
 GRADE_STATS_COLUMNS = {
     Grade.XH: "xh_count",
     Grade.X: "x_count",
@@ -304,6 +312,37 @@ async def save_replay_file(
         )
         if score.player.is_online:
             score.player.logout()
+
+
+def format_score_submission_performance(score: Score) -> str:
+    assert score.bmap is not None
+
+    if score.bmap.status == RankedStatus.Loved and score.mode in VANILLA_GAME_MODES:
+        return f"{score.score:,} score"
+
+    return f"{score.pp:,.2f}pp"
+
+
+def notify_personal_best(
+    score: Score,
+    *,
+    send_notification: Callable[[Player, str], None],
+) -> str | None:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    if score.status != SubmissionStatus.BEST:
+        return None
+
+    if not score.bmap.has_leaderboard:
+        return None
+
+    performance = format_score_submission_performance(score)
+    send_notification(
+        score.player,
+        f"You achieved #{score.rank}! ({performance})",
+    )
+    return performance
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> StatsUpdates:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -158,7 +158,7 @@ def _stats() -> tuple[ModeData, ModeData]:
     return previous, current
 
 
-class _ReplayFile:
+class _FakeReplayFile:
     def __init__(self, data: bytes) -> None:
         self.data = data
         self.read_count = 0
@@ -168,7 +168,7 @@ class _ReplayFile:
         return self.data
 
 
-class _ReplayPlayer:
+class _FakeReplayPlayer:
     def __init__(self, *, restricted: bool = False, online: bool = True) -> None:
         self.id = 6
         self.name = "test-user"
@@ -190,7 +190,7 @@ class _ReplayPlayer:
         self.is_online = False
 
 
-class _AnnounceChannel:
+class _FakeAnnounceChannel:
     def __init__(self) -> None:
         self.messages: list[tuple[str, object, bool]] = []
 
@@ -198,7 +198,7 @@ class _AnnounceChannel:
         self.messages.append((msg, sender, to_self))
 
 
-class _FirstPlaceScoresRepository:
+class _FakeFirstPlaceScoresRepository:
     def __init__(self, previous_first_place: dict[str, object] | None = None) -> None:
         self.previous_first_place = previous_first_place
         self.calls: list[dict[str, object]] = []
@@ -222,10 +222,10 @@ class _FirstPlaceScoresRepository:
 
 async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
     score = _score()
-    player = _ReplayPlayer()
+    player = _FakeReplayPlayer()
     score.player = player
     replay_data = b"x" * score_submission.MIN_REPLAY_SIZE
-    replay_file = _ReplayFile(replay_data)
+    replay_file = _FakeReplayFile(replay_data)
     missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
@@ -245,10 +245,10 @@ async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
 
 async def test_save_replay_file_does_not_read_failed_score(tmp_path) -> None:
     score = _score()
-    player = _ReplayPlayer()
+    player = _FakeReplayPlayer()
     score.player = player
     score.passed = False
-    replay_file = _ReplayFile(b"")
+    replay_file = _FakeReplayFile(b"")
     missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
@@ -269,10 +269,10 @@ async def test_save_replay_file_restricts_unrestricted_player_without_replay(
     tmp_path,
 ) -> None:
     score = _score()
-    player = _ReplayPlayer()
-    admin = _ReplayPlayer()
+    player = _FakeReplayPlayer()
+    admin = _FakeReplayPlayer()
     score.player = player
-    replay_file = _ReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
+    replay_file = _FakeReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
     missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
@@ -296,9 +296,9 @@ async def test_save_replay_file_does_not_restrict_restricted_player_without_repl
     tmp_path,
 ) -> None:
     score = _score()
-    player = _ReplayPlayer(restricted=True)
+    player = _FakeReplayPlayer(restricted=True)
     score.player = player
-    replay_file = _ReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
+    replay_file = _FakeReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
     missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
@@ -406,10 +406,10 @@ def test_notify_score_submitter_skips_no_leaderboard() -> None:
 
 async def test_announce_first_place_sends_message_with_previous_first_place() -> None:
     score = _score()
-    scores = _FirstPlaceScoresRepository(
+    scores = _FakeFirstPlaceScoresRepository(
         {"id": 9, "name": "old-user"},
     )
-    channel = _AnnounceChannel()
+    channel = _FakeAnnounceChannel()
 
     await score_submission.announce_first_place(
         score,
@@ -439,10 +439,10 @@ async def test_announce_first_place_sends_message_with_previous_first_place() ->
 async def test_announce_first_place_omits_previous_holder_for_same_player() -> None:
     score = _score()
     score.mods = Mods.NOMOD
-    scores = _FirstPlaceScoresRepository(
+    scores = _FakeFirstPlaceScoresRepository(
         {"id": 6, "name": "test-user"},
     )
-    channel = _AnnounceChannel()
+    channel = _FakeAnnounceChannel()
 
     await score_submission.announce_first_place(
         score,
@@ -467,8 +467,8 @@ async def test_announce_first_place_uses_score_for_vanilla_loved_score() -> None
     score.mode = GameMode.VANILLA_OSU
     score.mods = Mods.NOMOD
     score.score = 1_234_567
-    scores = _FirstPlaceScoresRepository()
-    channel = _AnnounceChannel()
+    scores = _FakeFirstPlaceScoresRepository()
+    channel = _FakeAnnounceChannel()
 
     await score_submission.announce_first_place(
         score,
@@ -514,10 +514,10 @@ async def test_announce_first_place_skips_ineligible_scores(condition: str) -> N
     elif condition == "no_leaderboard":
         score.bmap.has_leaderboard = False
 
-    scores = _FirstPlaceScoresRepository(
+    scores = _FakeFirstPlaceScoresRepository(
         {"id": 9, "name": "old-user"},
     )
-    channel = _AnnounceChannel()
+    channel = _FakeAnnounceChannel()
 
     await score_submission.announce_first_place(
         score,
@@ -532,7 +532,7 @@ async def test_announce_first_place_skips_ineligible_scores(condition: str) -> N
 
 async def test_announce_first_place_requires_announce_channel() -> None:
     score = _score()
-    scores = _FirstPlaceScoresRepository()
+    scores = _FakeFirstPlaceScoresRepository()
 
     with pytest.raises(AssertionError):
         await score_submission.announce_first_place(

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -155,6 +155,135 @@ def _stats() -> tuple[ModeData, ModeData]:
     return previous, current
 
 
+class _ReplayFile:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.read_count = 0
+
+    async def read(self) -> bytes:
+        self.read_count += 1
+        return self.data
+
+
+class _ReplayPlayer:
+    def __init__(self, *, restricted: bool = False, online: bool = True) -> None:
+        self.id = 6
+        self.name = "test-user"
+        self.restricted = restricted
+        self.is_online = online
+        self.restriction_reasons: list[str] = []
+        self.restriction_admins: list[object] = []
+        self.logged_out = False
+
+    def __repr__(self) -> str:
+        return f"<{self.name} ({self.id})>"
+
+    async def restrict(self, admin: object, reason: str) -> None:
+        self.restriction_admins.append(admin)
+        self.restriction_reasons.append(reason)
+
+    def logout(self) -> None:
+        self.logged_out = True
+        self.is_online = False
+
+
+async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
+    score = _score()
+    player = _ReplayPlayer()
+    score.player = player
+    replay_data = b"x" * score_submission.MIN_REPLAY_SIZE
+    replay_file = _ReplayFile(replay_data)
+    missing_replay_logs: list[str] = []
+
+    await score_submission.save_replay_file(
+        score,
+        replay_file=replay_file,
+        replays_path=tmp_path,
+        restriction_admin=player,
+        log_missing_replay=missing_replay_logs.append,
+    )
+
+    assert (tmp_path / "42.osr").read_bytes() == replay_data
+    assert replay_file.read_count == 1
+    assert missing_replay_logs == []
+    assert player.restriction_reasons == []
+    assert not player.logged_out
+
+
+async def test_save_replay_file_does_not_read_failed_score(tmp_path) -> None:
+    score = _score()
+    player = _ReplayPlayer()
+    score.player = player
+    score.passed = False
+    replay_file = _ReplayFile(b"")
+    missing_replay_logs: list[str] = []
+
+    await score_submission.save_replay_file(
+        score,
+        replay_file=replay_file,
+        replays_path=tmp_path,
+        restriction_admin=player,
+        log_missing_replay=missing_replay_logs.append,
+    )
+
+    assert replay_file.read_count == 0
+    assert list(tmp_path.iterdir()) == []
+    assert missing_replay_logs == []
+    assert player.restriction_reasons == []
+
+
+async def test_save_replay_file_restricts_unrestricted_player_without_replay(
+    tmp_path,
+) -> None:
+    score = _score()
+    player = _ReplayPlayer()
+    admin = _ReplayPlayer()
+    score.player = player
+    replay_file = _ReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
+    missing_replay_logs: list[str] = []
+
+    await score_submission.save_replay_file(
+        score,
+        replay_file=replay_file,
+        replays_path=tmp_path,
+        restriction_admin=admin,
+        log_missing_replay=missing_replay_logs.append,
+    )
+
+    assert list(tmp_path.iterdir()) == []
+    assert missing_replay_logs == [
+        "<test-user (6)> submitted a score without a replay!",
+    ]
+    assert player.restriction_admins == [admin]
+    assert player.restriction_reasons == ["submitted score with no replay"]
+    assert player.logged_out
+
+
+async def test_save_replay_file_does_not_restrict_restricted_player_without_replay(
+    tmp_path,
+) -> None:
+    score = _score()
+    player = _ReplayPlayer(restricted=True)
+    score.player = player
+    replay_file = _ReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
+    missing_replay_logs: list[str] = []
+
+    await score_submission.save_replay_file(
+        score,
+        replay_file=replay_file,
+        replays_path=tmp_path,
+        restriction_admin=player,
+        log_missing_replay=missing_replay_logs.append,
+    )
+
+    assert list(tmp_path.iterdir()) == []
+    assert missing_replay_logs == [
+        "<test-user (6)> submitted a score without a replay!",
+    ]
+    assert player.restriction_reasons == []
+    assert not player.logged_out
+
+
 class _FailingAchievements:
     async def fetch_many(self) -> list[dict[str, object]]:
         raise AssertionError("achievements should not be fetched")

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 
 from app._typing import UNSET
+from app.constants.beatmap_statuses import RankedStatus
 from app.constants.clientflags import ClientFlags
 from app.constants.gamemodes import GameMode
 from app.constants.mods import Mods
@@ -76,8 +77,10 @@ def _score() -> Score:
         plays=1,
         passes=1,
         last_update="2014-05-18 15:41:48",
+        status=RankedStatus.Ranked,
         has_leaderboard=True,
         awards_ranked_pp=True,
+        embed="[https://osu.cmyui.xyz/b/315 test map]",
         set=SimpleNamespace(url="https://osu.cmyui.xyz/s/141"),
     )
     return score
@@ -282,6 +285,93 @@ async def test_save_replay_file_does_not_restrict_restricted_player_without_repl
     ]
     assert player.restriction_reasons == []
     assert not player.logged_out
+
+
+def test_notify_personal_best_sends_pp_notification_for_ranked_score() -> None:
+    score = _score()
+    notifications: list[tuple[object, str]] = []
+
+    performance = score_submission.notify_personal_best(
+        score,
+        send_notification=lambda player, message: notifications.append(
+            (player, message),
+        ),
+    )
+
+    assert performance == "10.45pp"
+    assert notifications == [
+        (score.player, "You achieved #1! (10.45pp)"),
+    ]
+
+
+def test_notify_personal_best_uses_score_for_vanilla_loved_score() -> None:
+    score = _score()
+    score.bmap.status = RankedStatus.Loved
+    score.mode = GameMode.VANILLA_OSU
+    score.score = 1_234_567
+    notifications: list[tuple[object, str]] = []
+
+    performance = score_submission.notify_personal_best(
+        score,
+        send_notification=lambda player, message: notifications.append(
+            (player, message),
+        ),
+    )
+
+    assert performance == "1,234,567 score"
+    assert notifications == [
+        (score.player, "You achieved #1! (1,234,567 score)"),
+    ]
+
+
+def test_notify_personal_best_uses_pp_for_relax_loved_score() -> None:
+    score = _score()
+    score.bmap.status = RankedStatus.Loved
+    notifications: list[tuple[object, str]] = []
+
+    performance = score_submission.notify_personal_best(
+        score,
+        send_notification=lambda player, message: notifications.append(
+            (player, message),
+        ),
+    )
+
+    assert performance == "10.45pp"
+    assert notifications == [
+        (score.player, "You achieved #1! (10.45pp)"),
+    ]
+
+
+def test_notify_personal_best_skips_non_best_score() -> None:
+    score = _score()
+    score.status = SubmissionStatus.SUBMITTED
+    notifications: list[tuple[object, str]] = []
+
+    performance = score_submission.notify_personal_best(
+        score,
+        send_notification=lambda player, message: notifications.append(
+            (player, message),
+        ),
+    )
+
+    assert performance is None
+    assert notifications == []
+
+
+def test_notify_personal_best_skips_map_without_leaderboard() -> None:
+    score = _score()
+    score.bmap.has_leaderboard = False
+    notifications: list[tuple[object, str]] = []
+
+    performance = score_submission.notify_personal_best(
+        score,
+        send_notification=lambda player, message: notifications.append(
+            (player, message),
+        ),
+    )
+
+    assert performance is None
+    assert notifications == []
 
 
 class _FailingAchievements:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -317,11 +317,11 @@ async def test_save_replay_file_does_not_restrict_restricted_player_without_repl
     assert not player.logged_out
 
 
-def test_notify_personal_best_sends_pp_notification_for_ranked_score() -> None:
+def test_notify_score_submitter_sends_pp_notification() -> None:
     score = _score()
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_personal_best(
+    performance = score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
@@ -334,14 +334,14 @@ def test_notify_personal_best_sends_pp_notification_for_ranked_score() -> None:
     ]
 
 
-def test_notify_personal_best_uses_score_for_vanilla_loved_score() -> None:
+def test_notify_score_submitter_uses_score_for_vanilla_loved() -> None:
     score = _score()
     score.bmap.status = RankedStatus.Loved
     score.mode = GameMode.VANILLA_OSU
     score.score = 1_234_567
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_personal_best(
+    performance = score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
@@ -354,12 +354,12 @@ def test_notify_personal_best_uses_score_for_vanilla_loved_score() -> None:
     ]
 
 
-def test_notify_personal_best_uses_pp_for_relax_loved_score() -> None:
+def test_notify_score_submitter_uses_pp_for_relax_loved() -> None:
     score = _score()
     score.bmap.status = RankedStatus.Loved
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_personal_best(
+    performance = score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
@@ -372,12 +372,12 @@ def test_notify_personal_best_uses_pp_for_relax_loved_score() -> None:
     ]
 
 
-def test_notify_personal_best_skips_non_best_score() -> None:
+def test_notify_score_submitter_skips_non_best_score() -> None:
     score = _score()
     score.status = SubmissionStatus.SUBMITTED
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_personal_best(
+    performance = score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
@@ -388,12 +388,12 @@ def test_notify_personal_best_skips_non_best_score() -> None:
     assert notifications == []
 
 
-def test_notify_personal_best_skips_map_without_leaderboard() -> None:
+def test_notify_score_submitter_skips_no_leaderboard() -> None:
     score = _score()
     score.bmap.has_leaderboard = False
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_personal_best(
+    performance = score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -190,6 +190,36 @@ class _ReplayPlayer:
         self.is_online = False
 
 
+class _AnnounceChannel:
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, object, bool]] = []
+
+    def send(self, msg: str, sender: object, to_self: bool = False) -> None:
+        self.messages.append((msg, sender, to_self))
+
+
+class _FirstPlaceScoresRepository:
+    def __init__(self, previous_first_place: dict[str, object] | None = None) -> None:
+        self.previous_first_place = previous_first_place
+        self.calls: list[dict[str, object]] = []
+
+    async def fetch_previous_first_place(
+        self,
+        *,
+        map_md5: str,
+        mode: int,
+        scoring_metric: str,
+    ) -> dict[str, object] | None:
+        self.calls.append(
+            {
+                "map_md5": map_md5,
+                "mode": mode,
+                "scoring_metric": scoring_metric,
+            },
+        )
+        return self.previous_first_place
+
+
 async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
     score = _score()
     player = _ReplayPlayer()
@@ -372,6 +402,153 @@ def test_notify_personal_best_skips_map_without_leaderboard() -> None:
 
     assert performance is None
     assert notifications == []
+
+
+async def test_announce_first_place_sends_message_with_previous_first_place() -> None:
+    score = _score()
+    scores = _FirstPlaceScoresRepository(
+        {"id": 9, "name": "old-user"},
+    )
+    channel = _AnnounceChannel()
+
+    await score_submission.announce_first_place(
+        score,
+        scores=scores,
+        announce_channel=channel,
+        domain="osu.cmyui.xyz",
+    )
+
+    assert scores.calls == [
+        {
+            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
+            "mode": GameMode.RELAX_OSU.value,
+            "scoring_metric": "pp",
+        },
+    ]
+    assert channel.messages == [
+        (
+            "\x01ACTION achieved #1 on [https://osu.cmyui.xyz/b/315 test map] "
+            "+HDRX with 81.94% for 10.45pp. "
+            "(Previous #1: [https://osu.cmyui.xyz/u/9 old-user])",
+            score.player,
+            True,
+        ),
+    ]
+
+
+async def test_announce_first_place_omits_previous_holder_for_same_player() -> None:
+    score = _score()
+    score.mods = Mods.NOMOD
+    scores = _FirstPlaceScoresRepository(
+        {"id": 6, "name": "test-user"},
+    )
+    channel = _AnnounceChannel()
+
+    await score_submission.announce_first_place(
+        score,
+        scores=scores,
+        announce_channel=channel,
+        domain="osu.cmyui.xyz",
+    )
+
+    assert channel.messages == [
+        (
+            "\x01ACTION achieved #1 on [https://osu.cmyui.xyz/b/315 test map] "
+            "with 81.94% for 10.45pp.",
+            score.player,
+            True,
+        ),
+    ]
+
+
+async def test_announce_first_place_uses_score_for_vanilla_loved_score() -> None:
+    score = _score()
+    score.bmap.status = RankedStatus.Loved
+    score.mode = GameMode.VANILLA_OSU
+    score.mods = Mods.NOMOD
+    score.score = 1_234_567
+    scores = _FirstPlaceScoresRepository()
+    channel = _AnnounceChannel()
+
+    await score_submission.announce_first_place(
+        score,
+        scores=scores,
+        announce_channel=channel,
+        domain="osu.cmyui.xyz",
+    )
+
+    assert scores.calls == [
+        {
+            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
+            "mode": GameMode.VANILLA_OSU.value,
+            "scoring_metric": "score",
+        },
+    ]
+    assert channel.messages == [
+        (
+            "\x01ACTION achieved #1 on [https://osu.cmyui.xyz/b/315 test map] "
+            "with 81.94% for 1,234,567 score.",
+            score.player,
+            True,
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        "non_best",
+        "rank_two",
+        "restricted",
+        "no_leaderboard",
+    ],
+)
+async def test_announce_first_place_skips_ineligible_scores(condition: str) -> None:
+    score = _score()
+    if condition == "non_best":
+        score.status = SubmissionStatus.SUBMITTED
+    elif condition == "rank_two":
+        score.rank = 2
+    elif condition == "restricted":
+        score.player.restricted = True
+    elif condition == "no_leaderboard":
+        score.bmap.has_leaderboard = False
+
+    scores = _FirstPlaceScoresRepository(
+        {"id": 9, "name": "old-user"},
+    )
+    channel = _AnnounceChannel()
+
+    await score_submission.announce_first_place(
+        score,
+        scores=scores,
+        announce_channel=channel,
+        domain="osu.cmyui.xyz",
+    )
+
+    assert scores.calls == []
+    assert channel.messages == []
+
+
+async def test_announce_first_place_requires_announce_channel() -> None:
+    score = _score()
+    scores = _FirstPlaceScoresRepository()
+
+    with pytest.raises(AssertionError):
+        await score_submission.announce_first_place(
+            score,
+            scores=scores,
+            announce_channel=None,
+            domain="osu.cmyui.xyz",
+        )
+
+    assert scores.calls == [
+        {
+            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
+            "mode": GameMode.RELAX_OSU.value,
+            "scoring_metric": "pp",
+        },
+    ]
 
 
 class _FailingAchievements:


### PR DESCRIPTION
## Summary
- Extract replay file persistence and missing-replay enforcement from the osu submission controller.
- Extract personal-best notification formatting/dispatch eligibility.
- Extract first-place announcement assembly and previous-#1 lookup into the score submission usecase/repository layer.
- Add unit coverage for replay handling, PB notification, first-place announcement eligibility, loved-map performance formatting, previous-holder links, and restricted/no-leaderboard skip paths.

## Verification
- `make type-check`
- `make utest`
- `make lint`
- `make test`

## Notes
- Checked osu replay docs and score infrastructure notes for behavior cues; this PR keeps bancho.py's existing score submission semantics intact while making the side effects testable.
