### PR TITLE
Add transaction boundary to score submission persistence

### DIFF
--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -629,6 +629,13 @@ async def osuSubmitModularSelector(
         if not score.player.restricted:
             app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
 
+    def log_missing_replay(message: str) -> None:
+        log(message, Ansi.LRED)
+
+    replay_data: bytes | None = None
+    first_place_announcement: str | None = None
+    stats_result: score_submission_usecases.ScoreSubmissionPersistenceResult
+
     # hold a lock around (check if submitted, submission) to ensure no duplicates
     # are submitted to the database, and potentially award duplicate score/pp/etc.
     async with app.state.score_submission_locks[score.client_checksum]:
@@ -663,54 +670,70 @@ async def osuSubmitModularSelector(
 
         # TODO: re-implement pp caps for non-whitelisted players?
 
+        replay_data = await score_submission_usecases.read_validated_replay_file(
+            score,
+            replay_file=replay_file,
+            restriction_admin=app.state.sessions.bot,
+            log_missing_replay=log_missing_replay,
+        )
+
         """ Score submission checks completed; submit the score. """
 
         if app.state.services.datadog:
             app.state.services.datadog.increment("bancho.submitted_scores")  # type: ignore[no-untyped-call]
 
-        def send_personal_best_notification(player: Player, message: str) -> None:
-            player.enqueue(app.packets.notification(message))
-
         if score.status == SubmissionStatus.BEST:
             if app.state.services.datadog:
                 app.state.services.datadog.increment("bancho.submitted_scores_best")  # type: ignore[no-untyped-call]
 
-            score_submission_usecases.notify_score_submitter_of_personal_best(
-                score,
-                send_notification=send_personal_best_notification,
+            first_place_announcement = (
+                await score_submission_usecases.build_first_place_announcement(
+                    score,
+                    scores=scores_repo,
+                    domain=app.settings.DOMAIN,
+                )
             )
 
-            announce_chan = app.state.sessions.channels.get_by_name("#announce")
-            await score_submission_usecases.announce_first_place(
-                score,
-                scores=scores_repo,
-                announce_channel=announce_chan,
-                domain=app.settings.DOMAIN,
-            )
+        stats_result = await score_submission_usecases.persist_score_submission(
+            score,
+            database=app.state.services.database,
+            scores=scores_repo,
+            stats=stats_repo,
+            maps=maps_repo,
+            achievements=achievements_usecases,
+            user_achievements=user_achievements_usecases,
+        )
 
-        await score_submission_usecases.persist_submitted_score(score, scores_repo)
-
-    def log_missing_replay(message: str) -> None:
-        log(message, Ansi.LRED)
-
-    await score_submission_usecases.save_replay_file(
+    score_submission_usecases.write_replay_file(
         score,
-        replay_file=replay_file,
+        replay_data=replay_data,
         replays_path=REPLAYS_PATH,
-        restriction_admin=app.state.sessions.bot,
-        log_missing_replay=log_missing_replay,
     )
 
     def publish_user_stats(player: Player) -> None:
         app.state.sessions.players.enqueue(app.packets.user_stats(player))
 
-    stats_result = await score_submission_usecases.persist_score_submission_stats(
+    await score_submission_usecases.apply_score_submission_side_effects(
         score,
-        stats=stats_repo,
-        scores=scores_repo,
-        maps=maps_repo,
+        stats_result,
         publish_user_stats=publish_user_stats,
     )
+
+    def send_personal_best_notification(player: Player, message: str) -> None:
+        player.enqueue(app.packets.notification(message))
+
+    if score.status == SubmissionStatus.BEST:
+        score_submission_usecases.notify_score_submitter_of_personal_best(
+            score,
+            send_notification=send_personal_best_notification,
+        )
+
+        announce_chan = app.state.sessions.channels.get_by_name("#announce")
+        score_submission_usecases.send_first_place_announcement(
+            score,
+            announcement=first_place_announcement,
+            announce_channel=announce_chan,
+        )
 
     response = await score_submission_usecases.build_score_submission_response(
         score=score,
@@ -719,6 +742,7 @@ async def osuSubmitModularSelector(
         domain=app.settings.DOMAIN,
         achievements=achievements_usecases,
         user_achievements=user_achievements_usecases,
+        unlocked_achievements=stats_result.unlocked_achievements,
     )
 
     log(

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -630,7 +630,7 @@ async def osuSubmitModularSelector(
             app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
 
     replay_data: bytes | None = None
-    stats_result: score_submission_usecases.ScoreSubmissionPersistenceResult
+    persistence_result: score_submission_usecases.ScoreSubmissionPersistenceResult
 
     # hold a lock around (check if submitted, submission) to ensure no duplicates
     # are submitted to the database, and potentially award duplicate score/pp/etc.
@@ -691,7 +691,7 @@ async def osuSubmitModularSelector(
             if app.state.services.datadog:
                 app.state.services.datadog.increment("bancho.submitted_scores_best")  # type: ignore[no-untyped-call]
 
-        stats_result = await score_submission_usecases.persist_score_submission(
+        persistence_result = await score_submission_usecases.persist_score_submission(
             score,
             database=app.state.services.database,
             scores=scores_repo,
@@ -712,7 +712,7 @@ async def osuSubmitModularSelector(
 
     await score_submission_usecases.apply_score_submission_side_effects(
         score,
-        stats_result,
+        persistence_result,
         publish_user_stats=publish_user_stats,
     )
 
@@ -728,24 +728,24 @@ async def osuSubmitModularSelector(
         announce_chan = app.state.sessions.channels.get_by_name("#announce")
         score_submission_usecases.announce_first_place(
             score,
-            previous_first_place_score=stats_result.previous_first_place_score,
+            previous_first_place_score=persistence_result.previous_first_place_score,
             announce_channel=announce_chan,
             domain=app.settings.DOMAIN,
         )
 
     response = await score_submission_usecases.build_score_submission_response(
         score=score,
-        previous_stats=stats_result.previous_stats,
-        current_stats=stats_result.current_stats,
+        previous_stats=persistence_result.previous_stats,
+        current_stats=persistence_result.current_stats,
         domain=app.settings.DOMAIN,
         achievements=achievements_usecases,
         user_achievements=user_achievements_usecases,
-        unlocked_achievements=stats_result.unlocked_achievements,
+        unlocked_achievements=persistence_result.unlocked_achievements,
     )
 
     log(
         f"[{score.mode!r}] {score.player} submitted a score! "
-        f"({score.status!r}, {score.pp:,.2f}pp / {stats_result.current_stats.pp:,}pp)",
+        f"({score.status!r}, {score.pp:,.2f}pp / {persistence_result.current_stats.pp:,}pp)",
         Ansi.LGREEN,
     )
 

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -666,11 +666,21 @@ async def osuSubmitModularSelector(
 
         # TODO: re-implement pp caps for non-whitelisted players?
 
-        replay_data = await score_submission_usecases.read_and_validate_replay_file(
+        replay_data = await score_submission_usecases.read_submitted_replay_file(
             score,
             replay_file=replay_file,
-            restriction_admin=app.state.sessions.bot,
         )
+        if (
+            replay_data is not None
+            and not score_submission_usecases.replay_data_is_valid(
+                replay_data,
+            )
+        ):
+            await score_submission_usecases.restrict_player_for_missing_replay(
+                score,
+                restriction_admin=app.state.sessions.bot,
+            )
+            replay_data = None
 
         """ Score submission checks completed; submit the score. """
 

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -733,13 +733,11 @@ async def osuSubmitModularSelector(
             domain=app.settings.DOMAIN,
         )
 
-    response = await score_submission_usecases.build_score_submission_response(
+    response = score_submission_usecases.build_score_submission_response(
         score=score,
         previous_stats=persistence_result.previous_stats,
         current_stats=persistence_result.current_stats,
         domain=app.settings.DOMAIN,
-        achievements=achievements_usecases,
-        user_achievements=user_achievements_usecases,
         unlocked_achievements=persistence_result.unlocked_achievements,
     )
 

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -629,9 +629,6 @@ async def osuSubmitModularSelector(
         if not score.player.restricted:
             app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
 
-    def log_missing_replay(message: str) -> None:
-        log(message, Ansi.LRED)
-
     replay_data: bytes | None = None
     stats_result: score_submission_usecases.ScoreSubmissionPersistenceResult
 
@@ -673,7 +670,6 @@ async def osuSubmitModularSelector(
             score,
             replay_file=replay_file,
             restriction_admin=app.state.sessions.bot,
-            log_missing_replay=log_missing_replay,
         )
 
         """ Score submission checks completed; submit the score. """

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -707,14 +707,17 @@ async def osuSubmitModularSelector(
         replays_path=REPLAYS_PATH,
     )
 
-    def publish_user_stats(player: Player) -> None:
-        app.state.sessions.players.enqueue(app.packets.user_stats(player))
+    assert score.player is not None
 
-    await score_submission_usecases.apply_score_submission_side_effects(
-        score,
-        persistence_result,
-        publish_user_stats=publish_user_stats,
-    )
+    if persistence_result.should_update_rank:
+        persistence_result.current_stats.rank = await score.player.update_rank(
+            score.mode,
+        )
+
+    if persistence_result.is_public_submission:
+        app.state.sessions.players.enqueue(app.packets.user_stats(score.player))
+
+    score.player.recent_scores[score.mode] = score
 
     def send_personal_best_notification(player: Player, message: str) -> None:
         player.enqueue(app.packets.notification(message))

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -633,7 +633,6 @@ async def osuSubmitModularSelector(
         log(message, Ansi.LRED)
 
     replay_data: bytes | None = None
-    first_place_announcement: str | None = None
     stats_result: score_submission_usecases.ScoreSubmissionPersistenceResult
 
     # hold a lock around (check if submitted, submission) to ensure no duplicates
@@ -686,14 +685,6 @@ async def osuSubmitModularSelector(
             if app.state.services.datadog:
                 app.state.services.datadog.increment("bancho.submitted_scores_best")  # type: ignore[no-untyped-call]
 
-            first_place_announcement = (
-                await score_submission_usecases.build_first_place_announcement(
-                    score,
-                    scores=scores_repo,
-                    domain=app.settings.DOMAIN,
-                )
-            )
-
         stats_result = await score_submission_usecases.persist_score_submission(
             score,
             database=app.state.services.database,
@@ -728,6 +719,13 @@ async def osuSubmitModularSelector(
             send_notification=send_personal_best_notification,
         )
 
+        first_place_announcement = (
+            score_submission_usecases.build_first_place_announcement(
+                score,
+                previous_first_place_score=stats_result.previous_first_place_score,
+                domain=app.settings.DOMAIN,
+            )
+        )
         announce_chan = app.state.sessions.channels.get_by_name("#announce")
         score_submission_usecases.send_first_place_announcement(
             score,

--- a/app/api/domains/osu.py
+++ b/app/api/domains/osu.py
@@ -669,7 +669,7 @@ async def osuSubmitModularSelector(
 
         # TODO: re-implement pp caps for non-whitelisted players?
 
-        replay_data = await score_submission_usecases.read_validated_replay_file(
+        replay_data = await score_submission_usecases.read_and_validate_replay_file(
             score,
             replay_file=replay_file,
             restriction_admin=app.state.sessions.bot,
@@ -719,18 +719,12 @@ async def osuSubmitModularSelector(
             send_notification=send_personal_best_notification,
         )
 
-        first_place_announcement = (
-            score_submission_usecases.build_first_place_announcement(
-                score,
-                previous_first_place_score=stats_result.previous_first_place_score,
-                domain=app.settings.DOMAIN,
-            )
-        )
         announce_chan = app.state.sessions.channels.get_by_name("#announce")
-        score_submission_usecases.send_first_place_announcement(
+        score_submission_usecases.announce_first_place(
             score,
-            announcement=first_place_announcement,
+            previous_first_place_score=stats_result.previous_first_place_score,
             announce_channel=announce_chan,
+            domain=app.settings.DOMAIN,
         )
 
     response = await score_submission_usecases.build_score_submission_response(

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -121,7 +121,7 @@ class Score(TypedDict):
     online_checksum: str
 
 
-class PreviousFirstPlace(TypedDict):
+class CurrentFirstPlaceScore(TypedDict):
     id: int
     name: str
 
@@ -264,12 +264,12 @@ async def fetch_weighted_best_performances(
     return cast(list[ScorePerformanceRow], scores)
 
 
-async def fetch_previous_first_place(
+async def fetch_current_first_place_score(
     *,
     map_md5: str,
     mode: int,
     scoring_metric: ScoringMetric,
-) -> PreviousFirstPlace | None:
+) -> CurrentFirstPlaceScore | None:
     leaderboard_value = ScoresTable.pp if scoring_metric == "pp" else ScoresTable.score
     select_stmt = (
         select(UsersTable.id, UsersTable.name)
@@ -285,8 +285,8 @@ async def fetch_previous_first_place(
         .limit(1)
     )
 
-    previous_first_place = await app.state.services.database.fetch_one(select_stmt)
-    return cast(PreviousFirstPlace | None, previous_first_place)
+    current_first_place_score = await app.state.services.database.fetch_one(select_stmt)
+    return cast(CurrentFirstPlaceScore | None, current_first_place_score)
 
 
 async def fetch_beatmap_leaderboard_scores(

--- a/app/repositories/scores.py
+++ b/app/repositories/scores.py
@@ -121,7 +121,7 @@ class Score(TypedDict):
     online_checksum: str
 
 
-class CurrentFirstPlaceScore(TypedDict):
+class FirstPlaceScore(TypedDict):
     id: int
     name: str
 
@@ -264,12 +264,12 @@ async def fetch_weighted_best_performances(
     return cast(list[ScorePerformanceRow], scores)
 
 
-async def fetch_current_first_place_score(
+async def fetch_first_place_score(
     *,
     map_md5: str,
     mode: int,
     scoring_metric: ScoringMetric,
-) -> CurrentFirstPlaceScore | None:
+) -> FirstPlaceScore | None:
     leaderboard_value = ScoresTable.pp if scoring_metric == "pp" else ScoresTable.score
     select_stmt = (
         select(UsersTable.id, UsersTable.name)
@@ -285,8 +285,8 @@ async def fetch_current_first_place_score(
         .limit(1)
     )
 
-    current_first_place_score = await app.state.services.database.fetch_one(select_stmt)
-    return cast(CurrentFirstPlaceScore | None, current_first_place_score)
+    first_place_score = await app.state.services.database.fetch_one(select_stmt)
+    return cast(FirstPlaceScore | None, first_place_score)
 
 
 async def fetch_beatmap_leaderboard_scores(

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -26,7 +26,7 @@ from app.objects.player import Player
 from app.objects.score import Grade
 from app.objects.score import Score
 from app.repositories.achievements import Achievement
-from app.repositories.scores import CurrentFirstPlaceScore
+from app.repositories.scores import FirstPlaceScore
 from app.repositories.scores import ScorePerformanceRow
 from app.repositories.user_achievements import UserAchievement
 
@@ -150,13 +150,13 @@ class ScoresRepository(Protocol):
         mode: int,
     ) -> Sequence[ScorePerformanceRow]: ...
 
-    async def fetch_current_first_place_score(
+    async def fetch_first_place_score(
         self,
         *,
         map_md5: str,
         mode: int,
         scoring_metric: ScoringMetric,
-    ) -> CurrentFirstPlaceScore | None: ...
+    ) -> FirstPlaceScore | None: ...
 
 
 class StatsRepository(Protocol):
@@ -210,7 +210,7 @@ class ScoreSubmissionPersistenceResult:
     score_id: int
     previous_stats: ModeData
     current_stats: ModeData
-    previous_first_place_score: CurrentFirstPlaceScore | None
+    previous_first_place_score: FirstPlaceScore | None
     unlocked_achievements: Sequence[Achievement]
     should_update_rank: bool
     should_publish_user_stats: bool
@@ -370,7 +370,7 @@ async def save_replay_file(
     restriction_admin: Player,
     log_missing_replay: Callable[[str], None],
 ) -> None:
-    replay_data = await read_validated_replay_file(
+    replay_data = await read_and_validate_replay_file(
         score,
         replay_file=replay_file,
         restriction_admin=restriction_admin,
@@ -379,7 +379,7 @@ async def save_replay_file(
     write_replay_file(score, replay_data=replay_data, replays_path=replays_path)
 
 
-async def read_validated_replay_file(
+async def read_and_validate_replay_file(
     score: Score,
     *,
     replay_file: ReplayFile,
@@ -474,42 +474,50 @@ async def fetch_previous_first_place_score(
     score: Score,
     *,
     scores: ScoresRepository,
-) -> CurrentFirstPlaceScore | None:
+) -> FirstPlaceScore | None:
     assert score.bmap is not None
-
-    if not score_should_announce_first_place(score):
-        return None
 
     # Before persistence, the current first-place row is the previous #1 for
     # this submission.
-    return await scores.fetch_current_first_place_score(
+    return await scores.fetch_first_place_score(
         map_md5=score.bmap.md5,
         mode=score.mode.value,
         scoring_metric=first_place_scoring_metric(score),
     )
 
 
-async def announce_first_place(
+def announce_first_place(
     score: Score,
     *,
-    scores: ScoresRepository,
+    previous_first_place_score: FirstPlaceScore | None,
     announce_channel: AnnouncementChannel | None,
     domain: str,
 ) -> None:
-    previous_first_place_score = await fetch_previous_first_place_score(
-        score,
-        scores=scores,
-    )
-    announcement = build_first_place_announcement(
-        score,
-        previous_first_place_score=previous_first_place_score,
-        domain=domain,
-    )
-    send_first_place_announcement(
-        score,
-        announcement=announcement,
-        announce_channel=announce_channel,
-    )
+    assert score.bmap is not None
+    assert score.player is not None
+
+    if not score_should_announce_first_place(score):
+        return
+
+    performance = format_score_submission_performance(score)
+    ann = [
+        f"\x01ACTION achieved #1 on {score.bmap.embed}",
+        f"with {score.acc:.2f}% for {performance}.",
+    ]
+
+    if score.mods:
+        ann.insert(1, f"+{score.mods!r}")
+
+    if previous_first_place_score:
+        if score.player.id != previous_first_place_score["id"]:
+            ann.append(
+                f"(Previous #1: [https://{domain}/u/"
+                f"{previous_first_place_score['id']} "
+                f"{previous_first_place_score['name']}])",
+            )
+
+    assert announce_channel is not None
+    announce_channel.send(" ".join(ann), sender=score.player, to_self=True)
 
 
 def capture_score_submission_state(score: Score) -> ScoreSubmissionStateSnapshot:
@@ -544,52 +552,6 @@ def restore_score_submission_state(
         score.player.recent_scores[score.mode] = snapshot.recent_score
     else:
         score.player.recent_scores.pop(score.mode, None)
-
-
-def build_first_place_announcement(
-    score: Score,
-    *,
-    previous_first_place_score: CurrentFirstPlaceScore | None,
-    domain: str,
-) -> str | None:
-    assert score.bmap is not None
-    assert score.player is not None
-
-    if not score_should_announce_first_place(score):
-        return None
-
-    performance = format_score_submission_performance(score)
-    ann = [
-        f"\x01ACTION achieved #1 on {score.bmap.embed}",
-        f"with {score.acc:.2f}% for {performance}.",
-    ]
-
-    if score.mods:
-        ann.insert(1, f"+{score.mods!r}")
-
-    if previous_first_place_score:
-        if score.player.id != previous_first_place_score["id"]:
-            ann.append(
-                f"(Previous #1: [https://{domain}/u/"
-                f"{previous_first_place_score['id']} "
-                f"{previous_first_place_score['name']}])",
-            )
-
-    return " ".join(ann)
-
-
-def send_first_place_announcement(
-    score: Score,
-    *,
-    announcement: str | None,
-    announce_channel: AnnouncementChannel | None,
-) -> None:
-    if announcement is None:
-        return
-
-    assert score.player is not None
-    assert announce_channel is not None
-    announce_channel.send(announcement, sender=score.player, to_self=True)
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> ScoreStatsUpdates:
@@ -850,9 +812,11 @@ async def persist_score_submission(
 
     try:
         async with database.transaction():
-            previous_first_place_score = await fetch_previous_first_place_score(
-                score,
-                scores=scores,
+            should_announce_first_place = score_should_announce_first_place(score)
+            previous_first_place_score = (
+                await fetch_previous_first_place_score(score, scores=scores)
+                if should_announce_first_place
+                else None
             )
             score_id = await persist_submitted_score(score, scores)
             stats_result = await persist_score_submission_stats(

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -835,26 +835,6 @@ async def persist_score_submission(
     )
 
 
-async def apply_score_submission_side_effects(
-    score: Score,
-    persistence_result: ScoreSubmissionPersistenceResult,
-    *,
-    publish_user_stats: Callable[[Player], None],
-) -> None:
-    assert score.player is not None
-
-    if persistence_result.should_update_rank:
-        persistence_result.current_stats.rank = await score.player.update_rank(
-            score.mode,
-        )
-
-    if persistence_result.is_public_submission:
-        publish_user_stats(score.player)
-
-    # update their recent score
-    score.player.recent_scores[score.mode] = score
-
-
 def chart_entry(
     name: str,
     before: float | int | None,

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -5,6 +5,7 @@ import hashlib
 from collections.abc import Callable
 from collections.abc import Mapping
 from collections.abc import Sequence
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -71,6 +72,10 @@ class WeightedPerformanceStatsUpdates(TypedDict):
 class BeatmapPlayStatsUpdates(TypedDict):
     plays: int
     passes: int
+
+
+class DatabaseTransactions(Protocol):
+    def transaction(self) -> AbstractAsyncContextManager[Any]: ...
 
 
 MIN_REPLAY_SIZE = 24
@@ -196,6 +201,28 @@ class UniqueIdHashes:
 class ScoreStatsPersistenceResult:
     previous_stats: ModeData
     current_stats: ModeData
+    should_update_rank: bool
+    should_publish_user_stats: bool
+
+
+@dataclass(frozen=True)
+class ScoreSubmissionPersistenceResult:
+    score_id: int
+    previous_stats: ModeData
+    current_stats: ModeData
+    unlocked_achievements: Sequence[Achievement]
+    should_update_rank: bool
+    should_publish_user_stats: bool
+
+
+@dataclass(frozen=True)
+class ScoreSubmissionStateSnapshot:
+    score_id: int | None
+    stats: ModeData
+    beatmap_plays: int
+    beatmap_passes: int
+    had_recent_score: bool
+    recent_score: Score | None
 
 
 def parse_unique_id_hashes(unique_ids: str) -> UniqueIdHashes:
@@ -342,18 +369,31 @@ async def save_replay_file(
     restriction_admin: Player,
     log_missing_replay: Callable[[str], None],
 ) -> None:
+    replay_data = await read_validated_replay_file(
+        score,
+        replay_file=replay_file,
+        restriction_admin=restriction_admin,
+        log_missing_replay=log_missing_replay,
+    )
+    write_replay_file(score, replay_data=replay_data, replays_path=replays_path)
+
+
+async def read_validated_replay_file(
+    score: Score,
+    *,
+    replay_file: ReplayFile,
+    restriction_admin: Player,
+    log_missing_replay: Callable[[str], None],
+) -> bytes | None:
     assert score.player is not None
 
     if not score.passed:
-        return
+        return None
 
     replay_data = await replay_file.read()
 
     if len(replay_data) >= MIN_REPLAY_SIZE:
-        assert score.id is not None
-        replay_disk_file = replays_path / f"{score.id}.osr"
-        replay_disk_file.write_bytes(replay_data)
-        return
+        return replay_data
 
     log_missing_replay(f"{score.player} submitted a score without a replay!")
 
@@ -364,6 +404,22 @@ async def save_replay_file(
         )
         if score.player.is_online:
             score.player.logout()
+
+    return None
+
+
+def write_replay_file(
+    score: Score,
+    *,
+    replay_data: bytes | None,
+    replays_path: Path,
+) -> None:
+    if replay_data is None:
+        return
+
+    assert score.id is not None
+    replay_disk_file = replays_path / f"{score.id}.osr"
+    replay_disk_file.write_bytes(replay_data)
 
 
 def format_score_submission_performance(score: Score) -> str:
@@ -408,20 +464,72 @@ async def announce_first_place(
     announce_channel: AnnouncementChannel | None,
     domain: str,
 ) -> None:
+    announcement = await build_first_place_announcement(
+        score,
+        scores=scores,
+        domain=domain,
+    )
+    send_first_place_announcement(
+        score,
+        announcement=announcement,
+        announce_channel=announce_channel,
+    )
+
+
+def capture_score_submission_state(score: Score) -> ScoreSubmissionStateSnapshot:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    current_stats = score.player.stats[score.mode]
+    return ScoreSubmissionStateSnapshot(
+        score_id=score.id,
+        stats=copy.deepcopy(current_stats),
+        beatmap_plays=score.bmap.plays,
+        beatmap_passes=score.bmap.passes,
+        had_recent_score=score.mode in score.player.recent_scores,
+        recent_score=score.player.recent_scores.get(score.mode),
+    )
+
+
+def restore_score_submission_state(
+    score: Score,
+    snapshot: ScoreSubmissionStateSnapshot,
+) -> None:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    score.id = snapshot.score_id
+    score.player.stats[score.mode] = snapshot.stats
+    score.bmap.plays = snapshot.beatmap_plays
+    score.bmap.passes = snapshot.beatmap_passes
+
+    if snapshot.had_recent_score:
+        assert snapshot.recent_score is not None
+        score.player.recent_scores[score.mode] = snapshot.recent_score
+    else:
+        score.player.recent_scores.pop(score.mode, None)
+
+
+async def build_first_place_announcement(
+    score: Score,
+    *,
+    scores: ScoresRepository,
+    domain: str,
+) -> str | None:
     assert score.bmap is not None
     assert score.player is not None
 
     if score.status != SubmissionStatus.BEST:
-        return
+        return None
 
     if not score.bmap.has_leaderboard:
-        return
+        return None
 
     if score.rank != 1:
-        return
+        return None
 
     if score.player.restricted:
-        return
+        return None
 
     performance = format_score_submission_performance(score)
     ann = [
@@ -446,8 +554,21 @@ async def announce_first_place(
                 f"{prev_n1['name']}])",
             )
 
+    return " ".join(ann)
+
+
+def send_first_place_announcement(
+    score: Score,
+    *,
+    announcement: str | None,
+    announce_channel: AnnouncementChannel | None,
+) -> None:
+    if announcement is None:
+        return
+
+    assert score.player is not None
     assert announce_channel is not None
-    announce_channel.send(" ".join(ann), sender=score.player, to_self=True)
+    announce_channel.send(announcement, sender=score.player, to_self=True)
 
 
 def apply_score_base_stats(score: Score, stats: ModeData) -> ScoreStatsUpdates:
@@ -613,7 +734,6 @@ async def persist_score_submission_stats(
     stats: StatsRepository,
     scores: ScoresRepository,
     maps: MapsRepository,
-    publish_user_stats: Callable[[Player], None],
 ) -> ScoreStatsPersistenceResult:
     assert score.bmap is not None
     assert score.player is not None
@@ -624,6 +744,7 @@ async def persist_score_submission_stats(
     previous_stats = copy.copy(current_stats)
 
     stats_updates = apply_score_stats(score, current_stats)
+    should_update_rank = False
 
     if score.passed and score.bmap.has_leaderboard:
         # player passed & map is ranked, approved, or loved.
@@ -650,8 +771,7 @@ async def persist_score_submission_stats(
             stats_updates["acc"] = weighted_updates["acc"]
             stats_updates["pp"] = weighted_updates["pp"]
 
-            # update global & country ranking
-            current_stats.rank = await score.player.update_rank(score.mode)
+            should_update_rank = True
 
     await stats.partial_update(
         score.player.id,
@@ -671,10 +791,8 @@ async def persist_score_submission_stats(
         pp=stats_updates.get("pp", UNSET),
     )
 
-    if not score.player.restricted:
-        # enqueue new stats info to all other users
-        publish_user_stats(score.player)
-
+    should_publish_user_stats = not score.player.restricted
+    if should_publish_user_stats:
         beatmap_updates = apply_beatmap_play_stats(score)
         await maps.partial_update(
             score.bmap.id,
@@ -682,13 +800,83 @@ async def persist_score_submission_stats(
             passes=beatmap_updates["passes"],
         )
 
-    # update their recent score
-    score.player.recent_scores[score.mode] = score
-
     return ScoreStatsPersistenceResult(
         previous_stats=previous_stats,
         current_stats=current_stats,
+        should_update_rank=should_update_rank,
+        should_publish_user_stats=should_publish_user_stats,
     )
+
+
+def score_can_unlock_achievements(score: Score) -> bool:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    return score.passed and score.bmap.awards_ranked_pp and not score.player.restricted
+
+
+async def persist_score_submission(
+    score: Score,
+    *,
+    database: DatabaseTransactions,
+    scores: ScoresRepository,
+    stats: StatsRepository,
+    maps: MapsRepository,
+    achievements: AchievementsService,
+    user_achievements: UserAchievementsService,
+) -> ScoreSubmissionPersistenceResult:
+    snapshot = capture_score_submission_state(score)
+
+    try:
+        async with database.transaction():
+            score_id = await persist_submitted_score(score, scores)
+            stats_result = await persist_score_submission_stats(
+                score,
+                stats=stats,
+                scores=scores,
+                maps=maps,
+            )
+            unlocked_achievements = (
+                await unlock_new_achievements(
+                    score=score,
+                    achievements=achievements,
+                    user_achievements=user_achievements,
+                )
+                if score_can_unlock_achievements(score)
+                else []
+            )
+    except BaseException:
+        restore_score_submission_state(score, snapshot)
+        raise
+
+    return ScoreSubmissionPersistenceResult(
+        score_id=score_id,
+        previous_stats=stats_result.previous_stats,
+        current_stats=stats_result.current_stats,
+        unlocked_achievements=unlocked_achievements,
+        should_update_rank=stats_result.should_update_rank,
+        should_publish_user_stats=stats_result.should_publish_user_stats,
+    )
+
+
+async def apply_score_submission_side_effects(
+    score: Score,
+    persistence_result: ScoreSubmissionPersistenceResult,
+    *,
+    publish_user_stats: Callable[[Player], None],
+) -> None:
+    assert score.player is not None
+
+    if persistence_result.should_update_rank:
+        persistence_result.current_stats.rank = await score.player.update_rank(
+            score.mode,
+        )
+
+    if persistence_result.should_publish_user_stats:
+        publish_user_stats(score.player)
+
+    # update their recent score
+    score.player.recent_scores[score.mode] = score
 
 
 def chart_entry(
@@ -828,6 +1016,7 @@ async def build_score_submission_response(
     domain: str,
     achievements: AchievementsService,
     user_achievements: UserAchievementsService,
+    unlocked_achievements: Sequence[Achievement] | None = None,
 ) -> bytes:
     if not score.passed:  # TODO: check if this is correct
         return b"error: no"
@@ -835,19 +1024,22 @@ async def build_score_submission_response(
     assert score.bmap is not None
     assert score.player is not None
 
-    if score.bmap.awards_ranked_pp and not score.player.restricted:
+    if unlocked_achievements is not None:
+        achievements_to_display = unlocked_achievements
+    elif score_can_unlock_achievements(score):
         unlocked_achievements = await unlock_new_achievements(
             score=score,
             achievements=achievements,
             user_achievements=user_achievements,
         )
+        achievements_to_display = unlocked_achievements
     else:
-        unlocked_achievements = []
+        achievements_to_display = []
 
     return build_submission_charts(
         score=score,
         previous_stats=previous_stats,
         current_stats=current_stats,
-        achievements=unlocked_achievements,
+        achievements=achievements_to_display,
         domain=domain,
     )

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -20,6 +20,8 @@ from app.constants.beatmap_statuses import RankedStatus
 from app.constants.gamemodes import GameMode
 from app.constants.score_statuses import SubmissionStatus
 from app.constants.scoring_metrics import ScoringMetric
+from app.logging import Ansi
+from app.logging import log
 from app.objects.player import ClientDetails
 from app.objects.player import ModeData
 from app.objects.player import Player
@@ -368,13 +370,11 @@ async def save_replay_file(
     replay_file: ReplayFile,
     replays_path: Path,
     restriction_admin: Player,
-    log_missing_replay: Callable[[str], None],
 ) -> None:
     replay_data = await read_and_validate_replay_file(
         score,
         replay_file=replay_file,
         restriction_admin=restriction_admin,
-        log_missing_replay=log_missing_replay,
     )
     write_replay_file(score, replay_data=replay_data, replays_path=replays_path)
 
@@ -384,7 +384,6 @@ async def read_and_validate_replay_file(
     *,
     replay_file: ReplayFile,
     restriction_admin: Player,
-    log_missing_replay: Callable[[str], None],
 ) -> bytes | None:
     assert score.player is not None
 
@@ -396,7 +395,7 @@ async def read_and_validate_replay_file(
     if len(replay_data) >= MIN_REPLAY_SIZE:
         return replay_data
 
-    log_missing_replay(f"{score.player} submitted a score without a replay!")
+    log(f"{score.player} submitted a score without a replay!", Ansi.LRED)
 
     if not score.player.restricted:
         await score.player.restrict(
@@ -436,22 +435,21 @@ def notify_score_submitter_of_personal_best(
     score: Score,
     *,
     send_notification: Callable[[Player, str], None],
-) -> str | None:
+) -> None:
     assert score.bmap is not None
     assert score.player is not None
 
     if score.status != SubmissionStatus.BEST:
-        return None
+        return
 
     if not score.bmap.has_leaderboard:
-        return None
+        return
 
     performance = format_score_submission_performance(score)
     send_notification(
         score.player,
         f"You achieved #{score.rank}! ({performance})",
     )
-    return performance
 
 
 def first_place_scoring_metric(score: Score) -> ScoringMetric:

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -204,7 +204,7 @@ class ScoreStatsPersistenceResult:
     previous_stats: ModeData
     current_stats: ModeData
     should_update_rank: bool
-    should_publish_user_stats: bool
+    is_public_submission: bool
 
 
 @dataclass(frozen=True)
@@ -215,7 +215,7 @@ class ScoreSubmissionPersistenceResult:
     previous_first_place_score: FirstPlaceScore | None
     unlocked_achievements: Sequence[Achievement]
     should_update_rank: bool
-    should_publish_user_stats: bool
+    is_public_submission: bool
 
 
 @dataclass(frozen=True)
@@ -760,8 +760,8 @@ async def persist_score_submission_stats(
         pp=stats_updates.get("pp", UNSET),
     )
 
-    should_publish_user_stats = not score.player.restricted
-    if should_publish_user_stats:
+    is_public_submission = not score.player.restricted
+    if is_public_submission:
         beatmap_updates = apply_beatmap_play_stats(score)
         await maps.partial_update(
             score.bmap.id,
@@ -773,7 +773,7 @@ async def persist_score_submission_stats(
         previous_stats=previous_stats,
         current_stats=current_stats,
         should_update_rank=should_update_rank,
-        should_publish_user_stats=should_publish_user_stats,
+        is_public_submission=is_public_submission,
     )
 
 
@@ -831,7 +831,7 @@ async def persist_score_submission(
         previous_first_place_score=previous_first_place_score,
         unlocked_achievements=unlocked_achievements,
         should_update_rank=stats_result.should_update_rank,
-        should_publish_user_stats=stats_result.should_publish_user_stats,
+        is_public_submission=stats_result.is_public_submission,
     )
 
 
@@ -848,7 +848,7 @@ async def apply_score_submission_side_effects(
             score.mode,
         )
 
-    if persistence_result.should_publish_user_stats:
+    if persistence_result.is_public_submission:
         publish_user_stats(score.player)
 
     # update their recent score

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -26,7 +26,7 @@ from app.objects.player import Player
 from app.objects.score import Grade
 from app.objects.score import Score
 from app.repositories.achievements import Achievement
-from app.repositories.scores import PreviousFirstPlace
+from app.repositories.scores import CurrentFirstPlaceScore
 from app.repositories.scores import ScorePerformanceRow
 from app.repositories.user_achievements import UserAchievement
 
@@ -150,13 +150,13 @@ class ScoresRepository(Protocol):
         mode: int,
     ) -> Sequence[ScorePerformanceRow]: ...
 
-    async def fetch_previous_first_place(
+    async def fetch_current_first_place_score(
         self,
         *,
         map_md5: str,
         mode: int,
         scoring_metric: ScoringMetric,
-    ) -> PreviousFirstPlace | None: ...
+    ) -> CurrentFirstPlaceScore | None: ...
 
 
 class StatsRepository(Protocol):
@@ -210,6 +210,7 @@ class ScoreSubmissionPersistenceResult:
     score_id: int
     previous_stats: ModeData
     current_stats: ModeData
+    previous_first_place_score: CurrentFirstPlaceScore | None
     unlocked_achievements: Sequence[Achievement]
     should_update_rank: bool
     should_publish_user_stats: bool
@@ -457,6 +458,37 @@ def first_place_scoring_metric(score: Score) -> ScoringMetric:
     return "pp" if score.mode >= GameMode.RELAX_OSU else "score"
 
 
+def score_should_announce_first_place(score: Score) -> bool:
+    assert score.bmap is not None
+    assert score.player is not None
+
+    return (
+        score.status == SubmissionStatus.BEST
+        and score.bmap.has_leaderboard
+        and score.rank == 1
+        and not score.player.restricted
+    )
+
+
+async def fetch_previous_first_place_score(
+    score: Score,
+    *,
+    scores: ScoresRepository,
+) -> CurrentFirstPlaceScore | None:
+    assert score.bmap is not None
+
+    if not score_should_announce_first_place(score):
+        return None
+
+    # Before persistence, the current first-place row is the previous #1 for
+    # this submission.
+    return await scores.fetch_current_first_place_score(
+        map_md5=score.bmap.md5,
+        mode=score.mode.value,
+        scoring_metric=first_place_scoring_metric(score),
+    )
+
+
 async def announce_first_place(
     score: Score,
     *,
@@ -464,9 +496,13 @@ async def announce_first_place(
     announce_channel: AnnouncementChannel | None,
     domain: str,
 ) -> None:
-    announcement = await build_first_place_announcement(
+    previous_first_place_score = await fetch_previous_first_place_score(
         score,
         scores=scores,
+    )
+    announcement = build_first_place_announcement(
+        score,
+        previous_first_place_score=previous_first_place_score,
         domain=domain,
     )
     send_first_place_announcement(
@@ -510,25 +546,16 @@ def restore_score_submission_state(
         score.player.recent_scores.pop(score.mode, None)
 
 
-async def build_first_place_announcement(
+def build_first_place_announcement(
     score: Score,
     *,
-    scores: ScoresRepository,
+    previous_first_place_score: CurrentFirstPlaceScore | None,
     domain: str,
 ) -> str | None:
     assert score.bmap is not None
     assert score.player is not None
 
-    if score.status != SubmissionStatus.BEST:
-        return None
-
-    if not score.bmap.has_leaderboard:
-        return None
-
-    if score.rank != 1:
-        return None
-
-    if score.player.restricted:
+    if not score_should_announce_first_place(score):
         return None
 
     performance = format_score_submission_performance(score)
@@ -540,18 +567,12 @@ async def build_first_place_announcement(
     if score.mods:
         ann.insert(1, f"+{score.mods!r}")
 
-    # If there was previously a score on the map, add old #1.
-    prev_n1 = await scores.fetch_previous_first_place(
-        map_md5=score.bmap.md5,
-        mode=score.mode.value,
-        scoring_metric=first_place_scoring_metric(score),
-    )
-
-    if prev_n1:
-        if score.player.id != prev_n1["id"]:
+    if previous_first_place_score:
+        if score.player.id != previous_first_place_score["id"]:
             ann.append(
-                f"(Previous #1: [https://{domain}/u/{prev_n1['id']} "
-                f"{prev_n1['name']}])",
+                f"(Previous #1: [https://{domain}/u/"
+                f"{previous_first_place_score['id']} "
+                f"{previous_first_place_score['name']}])",
             )
 
     return " ".join(ann)
@@ -829,6 +850,10 @@ async def persist_score_submission(
 
     try:
         async with database.transaction():
+            previous_first_place_score = await fetch_previous_first_place_score(
+                score,
+                scores=scores,
+            )
             score_id = await persist_submitted_score(score, scores)
             stats_result = await persist_score_submission_stats(
                 score,
@@ -853,6 +878,7 @@ async def persist_score_submission(
         score_id=score_id,
         previous_stats=stats_result.previous_stats,
         current_stats=stats_result.current_stats,
+        previous_first_place_score=previous_first_place_score,
         unlocked_achievements=unlocked_achievements,
         should_update_rank=stats_result.should_update_rank,
         should_publish_user_stats=stats_result.should_publish_user_stats,

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -364,37 +364,27 @@ async def persist_submitted_score(score: Score, scores: ScoresRepository) -> int
     return score_id
 
 
-async def save_replay_file(
+async def read_submitted_replay_file(
     score: Score,
     *,
     replay_file: ReplayFile,
-    replays_path: Path,
-    restriction_admin: Player,
-) -> None:
-    replay_data = await read_and_validate_replay_file(
-        score,
-        replay_file=replay_file,
-        restriction_admin=restriction_admin,
-    )
-    write_replay_file(score, replay_data=replay_data, replays_path=replays_path)
-
-
-async def read_and_validate_replay_file(
-    score: Score,
-    *,
-    replay_file: ReplayFile,
-    restriction_admin: Player,
 ) -> bytes | None:
-    assert score.player is not None
-
     if not score.passed:
         return None
 
-    replay_data = await replay_file.read()
+    return await replay_file.read()
 
-    if len(replay_data) >= MIN_REPLAY_SIZE:
-        return replay_data
 
+def replay_data_is_valid(replay_data: bytes) -> bool:
+    return len(replay_data) >= MIN_REPLAY_SIZE
+
+
+async def restrict_player_for_missing_replay(
+    score: Score,
+    *,
+    restriction_admin: Player,
+) -> None:
+    assert score.player is not None
     log(f"{score.player} submitted a score without a replay!", Ansi.LRED)
 
     if not score.player.restricted:
@@ -404,8 +394,6 @@ async def read_and_validate_replay_file(
         )
         if score.player.is_online:
             score.player.logout()
-
-    return None
 
 
 def write_replay_file(

--- a/app/usecases/score_submission.py
+++ b/app/usecases/score_submission.py
@@ -984,15 +984,13 @@ def build_submission_charts(
     return "|".join(submission_charts).encode()
 
 
-async def build_score_submission_response(
+def build_score_submission_response(
     *,
     score: Score,
     previous_stats: ModeData,
     current_stats: ModeData,
     domain: str,
-    achievements: AchievementsService,
-    user_achievements: UserAchievementsService,
-    unlocked_achievements: Sequence[Achievement] | None = None,
+    unlocked_achievements: Sequence[Achievement],
 ) -> bytes:
     if not score.passed:  # TODO: check if this is correct
         return b"error: no"
@@ -1000,22 +998,10 @@ async def build_score_submission_response(
     assert score.bmap is not None
     assert score.player is not None
 
-    if unlocked_achievements is not None:
-        achievements_to_display = unlocked_achievements
-    elif score_can_unlock_achievements(score):
-        unlocked_achievements = await unlock_new_achievements(
-            score=score,
-            achievements=achievements,
-            user_achievements=user_achievements,
-        )
-        achievements_to_display = unlocked_achievements
-    else:
-        achievements_to_display = []
-
     return build_submission_charts(
         score=score,
         previous_stats=previous_stats,
         current_stats=current_stats,
-        achievements=achievements_to_display,
+        achievements=unlocked_achievements,
         domain=domain,
     )

--- a/tests/integration/repositories/scores_test.py
+++ b/tests/integration/repositories/scores_test.py
@@ -99,11 +99,11 @@ async def test_fetch_beatmap_leaderboard_scores_orders_by_pp_and_formats_clan_na
     ]
 
 
-async def test_fetch_current_first_place_score_uses_metric_and_ignores_restricted_users() -> (
+async def test_fetch_first_place_score_uses_metric_and_ignores_restricted_users() -> (
     None
 ):
     beatmap = await factories.create_map()
-    current_first_place_player = await factories.create_user()
+    first_place_player = await factories.create_user()
     higher_score_player = await factories.create_user()
     restricted_higher_pp_player = await factories.create_user()
     await users_repo.partial_update(
@@ -112,7 +112,7 @@ async def test_fetch_current_first_place_score_uses_metric_and_ignores_restricte
     )
 
     await factories.create_score(
-        player_id=current_first_place_player["id"],
+        player_id=first_place_player["id"],
         map_md5=beatmap["md5"],
         score=800_000,
         pp=300.0,
@@ -133,15 +133,15 @@ async def test_fetch_current_first_place_score_uses_metric_and_ignores_restricte
         mods=0,
     )
 
-    current_first_place_score = await scores_repo.fetch_current_first_place_score(
+    first_place_score = await scores_repo.fetch_first_place_score(
         map_md5=beatmap["md5"],
         mode=0,
         scoring_metric="pp",
     )
 
-    assert current_first_place_score == {
-        "id": current_first_place_player["id"],
-        "name": current_first_place_player["name"],
+    assert first_place_score == {
+        "id": first_place_player["id"],
+        "name": first_place_player["name"],
     }
 
 

--- a/tests/integration/repositories/scores_test.py
+++ b/tests/integration/repositories/scores_test.py
@@ -99,11 +99,11 @@ async def test_fetch_beatmap_leaderboard_scores_orders_by_pp_and_formats_clan_na
     ]
 
 
-async def test_fetch_previous_first_place_uses_metric_and_ignores_restricted_users() -> (
+async def test_fetch_current_first_place_score_uses_metric_and_ignores_restricted_users() -> (
     None
 ):
     beatmap = await factories.create_map()
-    previous_first_place_player = await factories.create_user()
+    current_first_place_player = await factories.create_user()
     higher_score_player = await factories.create_user()
     restricted_higher_pp_player = await factories.create_user()
     await users_repo.partial_update(
@@ -112,7 +112,7 @@ async def test_fetch_previous_first_place_uses_metric_and_ignores_restricted_use
     )
 
     await factories.create_score(
-        player_id=previous_first_place_player["id"],
+        player_id=current_first_place_player["id"],
         map_md5=beatmap["md5"],
         score=800_000,
         pp=300.0,
@@ -133,15 +133,15 @@ async def test_fetch_previous_first_place_uses_metric_and_ignores_restricted_use
         mods=0,
     )
 
-    previous_first_place = await scores_repo.fetch_previous_first_place(
+    current_first_place_score = await scores_repo.fetch_current_first_place_score(
         map_md5=beatmap["md5"],
         mode=0,
         scoring_metric="pp",
     )
 
-    assert previous_first_place == {
-        "id": previous_first_place_player["id"],
-        "name": previous_first_place_player["name"],
+    assert current_first_place_score == {
+        "id": current_first_place_player["id"],
+        "name": current_first_place_player["name"],
     }
 
 

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -293,19 +293,16 @@ async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
     score.player = player
     replay_data = b"x" * score_submission.MIN_REPLAY_SIZE
     replay_file = _FakeReplayFile(replay_data)
-    missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
         score,
         replay_file=replay_file,
         replays_path=tmp_path,
         restriction_admin=player,
-        log_missing_replay=missing_replay_logs.append,
     )
 
     assert (tmp_path / "42.osr").read_bytes() == replay_data
     assert replay_file.read_count == 1
-    assert missing_replay_logs == []
     assert player.restriction_reasons == []
     assert not player.logged_out
 
@@ -316,19 +313,16 @@ async def test_save_replay_file_does_not_read_failed_score(tmp_path) -> None:
     score.player = player
     score.passed = False
     replay_file = _FakeReplayFile(b"")
-    missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
         score,
         replay_file=replay_file,
         replays_path=tmp_path,
         restriction_admin=player,
-        log_missing_replay=missing_replay_logs.append,
     )
 
     assert replay_file.read_count == 0
     assert list(tmp_path.iterdir()) == []
-    assert missing_replay_logs == []
     assert player.restriction_reasons == []
 
 
@@ -340,20 +334,15 @@ async def test_save_replay_file_restricts_unrestricted_player_without_replay(
     admin = _FakeReplayPlayer()
     score.player = player
     replay_file = _FakeReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
-    missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
         score,
         replay_file=replay_file,
         replays_path=tmp_path,
         restriction_admin=admin,
-        log_missing_replay=missing_replay_logs.append,
     )
 
     assert list(tmp_path.iterdir()) == []
-    assert missing_replay_logs == [
-        "<test-user (6)> submitted a score without a replay!",
-    ]
     assert player.restriction_admins == [admin]
     assert player.restriction_reasons == ["submitted score with no replay"]
     assert player.logged_out
@@ -366,20 +355,15 @@ async def test_save_replay_file_does_not_restrict_restricted_player_without_repl
     player = _FakeReplayPlayer(restricted=True)
     score.player = player
     replay_file = _FakeReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
-    missing_replay_logs: list[str] = []
 
     await score_submission.save_replay_file(
         score,
         replay_file=replay_file,
         replays_path=tmp_path,
         restriction_admin=player,
-        log_missing_replay=missing_replay_logs.append,
     )
 
     assert list(tmp_path.iterdir()) == []
-    assert missing_replay_logs == [
-        "<test-user (6)> submitted a score without a replay!",
-    ]
     assert player.restriction_reasons == []
     assert not player.logged_out
 
@@ -388,14 +372,13 @@ def test_notify_score_submitter_sends_pp_notification() -> None:
     score = _score()
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_score_submitter_of_personal_best(
+    score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
         ),
     )
 
-    assert performance == "10.45pp"
     assert notifications == [
         (score.player, "You achieved #1! (10.45pp)"),
     ]
@@ -408,14 +391,13 @@ def test_notify_score_submitter_uses_score_for_vanilla_loved() -> None:
     score.score = 1_234_567
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_score_submitter_of_personal_best(
+    score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
         ),
     )
 
-    assert performance == "1,234,567 score"
     assert notifications == [
         (score.player, "You achieved #1! (1,234,567 score)"),
     ]
@@ -426,14 +408,13 @@ def test_notify_score_submitter_uses_pp_for_relax_loved() -> None:
     score.bmap.status = RankedStatus.Loved
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_score_submitter_of_personal_best(
+    score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
         ),
     )
 
-    assert performance == "10.45pp"
     assert notifications == [
         (score.player, "You achieved #1! (10.45pp)"),
     ]
@@ -444,14 +425,13 @@ def test_notify_score_submitter_skips_non_best_score() -> None:
     score.status = SubmissionStatus.SUBMITTED
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_score_submitter_of_personal_best(
+    score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
         ),
     )
 
-    assert performance is None
     assert notifications == []
 
 
@@ -460,14 +440,13 @@ def test_notify_score_submitter_skips_no_leaderboard() -> None:
     score.bmap.has_leaderboard = False
     notifications: list[tuple[object, str]] = []
 
-    performance = score_submission.notify_score_submitter_of_personal_best(
+    score_submission.notify_score_submitter_of_personal_best(
         score,
         send_notification=lambda player, message: notifications.append(
             (player, message),
         ),
     )
 
-    assert performance is None
     assert notifications == []
 
 

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -25,13 +25,13 @@ from app.objects.player import OsuVersion
 from app.objects.score import Grade
 from app.objects.score import Score
 from app.repositories.achievements import Achievement
-from app.repositories.scores import PreviousFirstPlace
+from app.repositories.scores import CurrentFirstPlaceScore
 from app.repositories.scores import ScorePerformanceRow
 from app.repositories.user_achievements import UserAchievement
 from app.usecases import score_submission
 
 
-class _PreviousFirstPlaceFetch(TypedDict):
+class _FirstPlaceScoreFetch(TypedDict):
     map_md5: str
     mode: int
     scoring_metric: ScoringMetric
@@ -263,17 +263,20 @@ class _FakeAnnounceChannel:
 
 
 class _FakeFirstPlaceScoresRepository:
-    def __init__(self, previous_first_place: PreviousFirstPlace | None = None) -> None:
-        self.previous_first_place = previous_first_place
-        self.calls: list[_PreviousFirstPlaceFetch] = []
+    def __init__(
+        self,
+        current_first_place_score: CurrentFirstPlaceScore | None = None,
+    ) -> None:
+        self.current_first_place_score = current_first_place_score
+        self.calls: list[_FirstPlaceScoreFetch] = []
 
-    async def fetch_previous_first_place(
+    async def fetch_current_first_place_score(
         self,
         *,
         map_md5: str,
         mode: int,
         scoring_metric: ScoringMetric,
-    ) -> PreviousFirstPlace | None:
+    ) -> CurrentFirstPlaceScore | None:
         self.calls.append(
             {
                 "map_md5": map_md5,
@@ -281,7 +284,7 @@ class _FakeFirstPlaceScoresRepository:
                 "scoring_metric": scoring_metric,
             },
         )
-        return self.previous_first_place
+        return self.current_first_place_score
 
 
 async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
@@ -719,12 +722,15 @@ class _FakeScoresRepository:
     def __init__(
         self,
         best_scores: list[ScorePerformanceRow] | None = None,
+        current_first_place_score: CurrentFirstPlaceScore | None = None,
     ) -> None:
         self.calls: list[str] = []
         self.previous_best_updates: list[_PreviousBestUpdate] = []
         self.created_scores: list[_CreatedScoreFields] = []
         self.best_scores = best_scores if best_scores is not None else []
+        self.current_first_place_score = current_first_place_score
         self.fetches: list[_ScorePerformanceFetch] = []
+        self.first_place_score_fetches: list[_FirstPlaceScoreFetch] = []
 
     async def create(
         self,
@@ -759,14 +765,22 @@ class _FakeScoresRepository:
         self.fetches.append({"user_id": user_id, "mode": mode})
         return self.best_scores
 
-    async def fetch_previous_first_place(
+    async def fetch_current_first_place_score(
         self,
         *,
         map_md5: str,
         mode: int,
         scoring_metric: ScoringMetric,
-    ) -> PreviousFirstPlace | None:
-        raise AssertionError("previous first place should not be fetched")
+    ) -> CurrentFirstPlaceScore | None:
+        self.calls.append("fetch_current_first_place_score")
+        self.first_place_score_fetches.append(
+            {
+                "map_md5": map_md5,
+                "mode": mode,
+                "scoring_metric": scoring_metric,
+            },
+        )
+        return self.current_first_place_score
 
 
 class _FakeScorePerformanceRepository:
@@ -1047,6 +1061,7 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
         score_id=123,
         previous_stats=result.previous_stats,
         current_stats=result.current_stats,
+        previous_first_place_score=None,
         unlocked_achievements=[],
         should_update_rank=result.should_update_rank,
         should_publish_user_stats=result.should_publish_user_stats,
@@ -1164,6 +1179,7 @@ async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None
             {"pp": 100.0, "acc": 98.0},
             {"pp": 50.0, "acc": 95.0},
         ],
+        current_first_place_score={"id": 9, "name": "old-user"},
     )
     maps = _FakeMapsRepository()
     user_achievements = _FakeUserAchievements()
@@ -1180,7 +1196,18 @@ async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None
 
     assert database.calls == ["transaction", "transaction_enter", "transaction_exit"]
     assert database.transactions[0].exception_type is None
-    assert scores.calls == ["mark_previous_best_scores_submitted", "create"]
+    assert scores.calls == [
+        "fetch_current_first_place_score",
+        "mark_previous_best_scores_submitted",
+        "create",
+    ]
+    assert scores.first_place_score_fetches == [
+        {
+            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
+            "mode": GameMode.RELAX_OSU.value,
+            "scoring_metric": "pp",
+        },
+    ]
     assert maps.partial_updates == [
         {
             "id": 315,
@@ -1192,6 +1219,7 @@ async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None
     ]
     assert user_achievements.created_achievement_ids == [1]
     assert result.score_id == 123
+    assert result.previous_first_place_score == {"id": 9, "name": "old-user"}
     assert [achievement["id"] for achievement in result.unlocked_achievements] == [1]
     assert result.should_update_rank
     assert result.should_publish_user_stats

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -589,27 +589,6 @@ def test_announce_first_place_requires_announce_channel() -> None:
         )
 
 
-class _FailingAchievements:
-    async def fetch_many(self) -> list[Achievement]:
-        raise AssertionError("achievements should not be fetched")
-
-
-class _FailingUserAchievements:
-    async def fetch_many(
-        self,
-        *,
-        user_id: int,
-    ) -> list[UserAchievement]:
-        raise AssertionError("user achievements should not be fetched")
-
-    async def create(
-        self,
-        user_id: int,
-        achievement_id: int,
-    ) -> UserAchievement:
-        raise AssertionError("user achievements should not be created")
-
-
 class _FakeAchievements:
     async def fetch_many(self) -> list[Achievement]:
         return [
@@ -1798,72 +1777,60 @@ def test_build_submission_charts_includes_previous_best_values() -> None:
     )
 
 
-async def test_build_score_submission_response_returns_error_for_failed_score() -> None:
+def test_build_score_submission_response_returns_error_for_failed_score() -> None:
     score = _score()
     score.passed = False
     previous_stats, current_stats = _stats()
 
-    response = await score_submission.build_score_submission_response(
+    response = score_submission.build_score_submission_response(
         score=score,
         previous_stats=previous_stats,
         current_stats=current_stats,
         domain="cmyui.xyz",
-        achievements=_FailingAchievements(),
-        user_achievements=_FailingUserAchievements(),
+        unlocked_achievements=[],
     )
 
     assert response == b"error: no"
 
 
-@pytest.mark.parametrize(
-    ("awards_ranked_pp", "restricted"),
-    [
-        (False, False),
-        (True, True),
-    ],
-)
-async def test_build_score_submission_response_skips_achievements_when_score_is_not_eligible(
-    awards_ranked_pp: bool,
-    restricted: bool,
-) -> None:
+def test_build_score_submission_response_formats_empty_achievements() -> None:
     score = _score()
-    score.bmap.awards_ranked_pp = awards_ranked_pp
-    score.player.restricted = restricted
     previous_stats, current_stats = _stats()
 
-    response = await score_submission.build_score_submission_response(
+    response = score_submission.build_score_submission_response(
         score=score,
         previous_stats=previous_stats,
         current_stats=current_stats,
         domain="cmyui.xyz",
-        achievements=_FailingAchievements(),
-        user_achievements=_FailingUserAchievements(),
+        unlocked_achievements=[],
     )
 
     assert b"achievements-new:" in response
     assert b"osu-skill-pass-4" not in response
 
 
-async def test_build_score_submission_response_unlocks_matching_new_achievements() -> (
-    None
-):
+def test_build_score_submission_response_formats_unlocked_achievements() -> None:
     score = _score()
     previous_stats, current_stats = _stats()
-    user_achievements = _FakeUserAchievements()
+    achievements = [
+        {
+            "id": 1,
+            "file": "osu-skill-pass-4",
+            "name": "Insanity Approaches",
+            "desc": "You're not twitching, you're just ready.",
+            "cond": lambda score, mode_vn: True,
+        },
+    ]
 
-    response = await score_submission.build_score_submission_response(
+    response = score_submission.build_score_submission_response(
         score=score,
         previous_stats=previous_stats,
         current_stats=current_stats,
         domain="cmyui.xyz",
-        achievements=_FakeAchievements(),
-        user_achievements=user_achievements,
+        unlocked_achievements=achievements,
     )
 
-    assert user_achievements.created_achievement_ids == [1]
     assert (
         b"achievements-new:osu-skill-pass-4+Insanity Approaches+You're not twitching, you're just ready."
         in response
     )
-    assert b"osu-combo-500" not in response
-    assert b"all-intro-hidden" not in response

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -287,85 +287,92 @@ class _FakeFirstPlaceScoresRepository:
         return self.first_place_score
 
 
-async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
+async def test_read_submitted_replay_file_returns_passed_replay() -> None:
     score = _score()
     player = _FakeReplayPlayer()
     score.player = player
     replay_data = b"x" * score_submission.MIN_REPLAY_SIZE
     replay_file = _FakeReplayFile(replay_data)
 
-    await score_submission.save_replay_file(
+    submitted_replay = await score_submission.read_submitted_replay_file(
         score,
         replay_file=replay_file,
-        replays_path=tmp_path,
-        restriction_admin=player,
     )
 
-    assert (tmp_path / "42.osr").read_bytes() == replay_data
+    assert submitted_replay == replay_data
     assert replay_file.read_count == 1
-    assert player.restriction_reasons == []
-    assert not player.logged_out
 
 
-async def test_save_replay_file_does_not_read_failed_score(tmp_path) -> None:
+async def test_read_submitted_replay_file_does_not_read_failed_score() -> None:
     score = _score()
     player = _FakeReplayPlayer()
     score.player = player
     score.passed = False
     replay_file = _FakeReplayFile(b"")
 
-    await score_submission.save_replay_file(
+    submitted_replay = await score_submission.read_submitted_replay_file(
         score,
         replay_file=replay_file,
-        replays_path=tmp_path,
-        restriction_admin=player,
     )
 
+    assert submitted_replay is None
     assert replay_file.read_count == 0
-    assert list(tmp_path.iterdir()) == []
-    assert player.restriction_reasons == []
 
 
-async def test_save_replay_file_restricts_unrestricted_player_without_replay(
-    tmp_path,
-) -> None:
+def test_replay_data_is_valid_requires_minimum_replay_size() -> None:
+    assert score_submission.replay_data_is_valid(
+        b"x" * score_submission.MIN_REPLAY_SIZE,
+    )
+    assert not score_submission.replay_data_is_valid(
+        b"x" * (score_submission.MIN_REPLAY_SIZE - 1),
+    )
+
+
+async def test_restrict_player_for_missing_replay_restricts_unrestricted_player() -> (
+    None
+):
     score = _score()
     player = _FakeReplayPlayer()
     admin = _FakeReplayPlayer()
     score.player = player
-    replay_file = _FakeReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
 
-    await score_submission.save_replay_file(
+    await score_submission.restrict_player_for_missing_replay(
         score,
-        replay_file=replay_file,
-        replays_path=tmp_path,
         restriction_admin=admin,
     )
 
-    assert list(tmp_path.iterdir()) == []
     assert player.restriction_admins == [admin]
     assert player.restriction_reasons == ["submitted score with no replay"]
     assert player.logged_out
 
 
-async def test_save_replay_file_does_not_restrict_restricted_player_without_replay(
-    tmp_path,
-) -> None:
+async def test_restrict_player_for_missing_replay_does_not_restrict_restricted_player() -> (
+    None
+):
     score = _score()
     player = _FakeReplayPlayer(restricted=True)
     score.player = player
-    replay_file = _FakeReplayFile(b"x" * (score_submission.MIN_REPLAY_SIZE - 1))
 
-    await score_submission.save_replay_file(
+    await score_submission.restrict_player_for_missing_replay(
         score,
-        replay_file=replay_file,
-        replays_path=tmp_path,
         restriction_admin=player,
     )
 
-    assert list(tmp_path.iterdir()) == []
     assert player.restriction_reasons == []
     assert not player.logged_out
+
+
+def test_write_replay_file_writes_replay_data(tmp_path) -> None:
+    score = _score()
+    replay_data = b"x" * score_submission.MIN_REPLAY_SIZE
+
+    score_submission.write_replay_file(
+        score,
+        replay_data=replay_data,
+        replays_path=tmp_path,
+    )
+
+    assert (tmp_path / "42.osr").read_bytes() == replay_data
 
 
 def test_notify_score_submitter_sends_pp_notification() -> None:

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -990,7 +990,7 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
     assert result.current_stats.pp == 148
     assert result.current_stats.rank == 0
     assert result.should_update_rank
-    assert result.should_publish_user_stats
+    assert result.is_public_submission
     assert player.updated_rank_modes == []
     assert scores_repo.fetches == [
         {
@@ -1035,7 +1035,7 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
         previous_first_place_score=None,
         unlocked_achievements=[],
         should_update_rank=result.should_update_rank,
-        should_publish_user_stats=result.should_publish_user_stats,
+        is_public_submission=result.is_public_submission,
     )
     await score_submission.apply_score_submission_side_effects(
         score,
@@ -1082,7 +1082,7 @@ async def test_persist_score_submission_stats_updates_failed_score_without_weigh
     assert result.current_stats.tscore == 26_820
     assert result.current_stats.total_hits == 109
     assert not result.should_update_rank
-    assert result.should_publish_user_stats
+    assert result.is_public_submission
     assert player.updated_rank_modes == []
     assert stats_repo.partial_updates == [
         {
@@ -1126,7 +1126,7 @@ async def test_persist_score_submission_stats_skips_public_side_effects_for_rest
     )
 
     assert stats_repo.partial_updates != []
-    assert not result.should_publish_user_stats
+    assert not result.is_public_submission
     assert publish_user_stats.published_players == []
     assert score.bmap.plays == 1
     assert score.bmap.passes == 1
@@ -1193,7 +1193,7 @@ async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None
     assert result.previous_first_place_score == {"id": 9, "name": "old-user"}
     assert [achievement["id"] for achievement in result.unlocked_achievements] == [1]
     assert result.should_update_rank
-    assert result.should_publish_user_stats
+    assert result.is_public_submission
     assert player.updated_rank_modes == []
     assert player.recent_scores == {}
 

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -810,14 +810,6 @@ class _FailingMapsRepository:
         raise RuntimeError("map update failed")
 
 
-class _FakeUserStatsPublisher:
-    def __init__(self) -> None:
-        self.published_players: list[object] = []
-
-    def __call__(self, player: object) -> None:
-        self.published_players.append(player)
-
-
 class _FakePlayer:
     def __init__(
         self,
@@ -949,7 +941,6 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
         ],
     )
     maps_repo = _FakeMapsRepository()
-    publish_user_stats = _FakeUserStatsPublisher()
 
     result = await score_submission.persist_score_submission_stats(
         score,
@@ -993,7 +984,6 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
             },
         },
     ]
-    assert publish_user_stats.published_players == []
     assert score.bmap.plays == 2
     assert score.bmap.passes == 2
     assert maps_repo.partial_updates == [
@@ -1006,26 +996,6 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
         },
     ]
     assert player.recent_scores == {}
-
-    persistence_result = score_submission.ScoreSubmissionPersistenceResult(
-        score_id=123,
-        previous_stats=result.previous_stats,
-        current_stats=result.current_stats,
-        previous_first_place_score=None,
-        unlocked_achievements=[],
-        should_update_rank=result.should_update_rank,
-        is_public_submission=result.is_public_submission,
-    )
-    await score_submission.apply_score_submission_side_effects(
-        score,
-        persistence_result,
-        publish_user_stats=publish_user_stats,
-    )
-
-    assert result.current_stats.rank == 7
-    assert player.updated_rank_modes == [GameMode.RELAX_OSU]
-    assert publish_user_stats.published_players == [player]
-    assert player.recent_scores[GameMode.RELAX_OSU] is score
 
 
 async def test_persist_score_submission_stats_updates_failed_score_without_weighted_stats() -> (
@@ -1046,7 +1016,6 @@ async def test_persist_score_submission_stats_updates_failed_score_without_weigh
     score.bmap.passes = 1
     stats_repo = _FakeStatsRepository()
     maps_repo = _FakeMapsRepository()
-    publish_user_stats = _FakeUserStatsPublisher()
 
     result = await score_submission.persist_score_submission_stats(
         score,
@@ -1075,11 +1044,10 @@ async def test_persist_score_submission_stats_updates_failed_score_without_weigh
             },
         },
     ]
-    assert publish_user_stats.published_players == []
     assert player.recent_scores == {}
 
 
-async def test_persist_score_submission_stats_skips_public_side_effects_for_restricted_player() -> (
+async def test_persist_score_submission_stats_skips_public_updates_for_restricted_player() -> (
     None
 ):
     score = _score()
@@ -1095,7 +1063,6 @@ async def test_persist_score_submission_stats_skips_public_side_effects_for_rest
     score.bmap.passes = 1
     stats_repo = _FakeStatsRepository()
     maps_repo = _FakeMapsRepository()
-    publish_user_stats = _FakeUserStatsPublisher()
 
     result = await score_submission.persist_score_submission_stats(
         score,
@@ -1106,7 +1073,6 @@ async def test_persist_score_submission_stats_skips_public_side_effects_for_rest
 
     assert stats_repo.partial_updates != []
     assert not result.is_public_submission
-    assert publish_user_stats.published_players == []
     assert score.bmap.plays == 1
     assert score.bmap.passes == 1
     assert maps_repo.partial_updates == []

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -25,7 +25,7 @@ from app.objects.player import OsuVersion
 from app.objects.score import Grade
 from app.objects.score import Score
 from app.repositories.achievements import Achievement
-from app.repositories.scores import CurrentFirstPlaceScore
+from app.repositories.scores import FirstPlaceScore
 from app.repositories.scores import ScorePerformanceRow
 from app.repositories.user_achievements import UserAchievement
 from app.usecases import score_submission
@@ -265,18 +265,18 @@ class _FakeAnnounceChannel:
 class _FakeFirstPlaceScoresRepository:
     def __init__(
         self,
-        current_first_place_score: CurrentFirstPlaceScore | None = None,
+        first_place_score: FirstPlaceScore | None = None,
     ) -> None:
-        self.current_first_place_score = current_first_place_score
+        self.first_place_score = first_place_score
         self.calls: list[_FirstPlaceScoreFetch] = []
 
-    async def fetch_current_first_place_score(
+    async def fetch_first_place_score(
         self,
         *,
         map_md5: str,
         mode: int,
         scoring_metric: ScoringMetric,
-    ) -> CurrentFirstPlaceScore | None:
+    ) -> FirstPlaceScore | None:
         self.calls.append(
             {
                 "map_md5": map_md5,
@@ -284,7 +284,7 @@ class _FakeFirstPlaceScoresRepository:
                 "scoring_metric": scoring_metric,
             },
         )
-        return self.current_first_place_score
+        return self.first_place_score
 
 
 async def test_save_replay_file_writes_passed_replay(tmp_path) -> None:
@@ -471,27 +471,36 @@ def test_notify_score_submitter_skips_no_leaderboard() -> None:
     assert notifications == []
 
 
-async def test_announce_first_place_sends_message_with_previous_first_place() -> None:
+async def test_fetch_previous_first_place_score_uses_score_for_vanilla_loved_score() -> (
+    None
+):
     score = _score()
-    scores = _FakeFirstPlaceScoresRepository(
-        {"id": 9, "name": "old-user"},
-    )
-    channel = _FakeAnnounceChannel()
+    score.bmap.status = RankedStatus.Loved
+    score.mode = GameMode.VANILLA_OSU
+    scores = _FakeFirstPlaceScoresRepository()
 
-    await score_submission.announce_first_place(
-        score,
-        scores=scores,
-        announce_channel=channel,
-        domain="osu.cmyui.xyz",
-    )
+    await score_submission.fetch_previous_first_place_score(score, scores=scores)
 
     assert scores.calls == [
         {
             "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
-            "mode": GameMode.RELAX_OSU.value,
-            "scoring_metric": "pp",
+            "mode": GameMode.VANILLA_OSU.value,
+            "scoring_metric": "score",
         },
     ]
+
+
+def test_announce_first_place_sends_message_with_previous_first_place() -> None:
+    score = _score()
+    channel = _FakeAnnounceChannel()
+
+    score_submission.announce_first_place(
+        score,
+        previous_first_place_score={"id": 9, "name": "old-user"},
+        announce_channel=channel,
+        domain="osu.cmyui.xyz",
+    )
+
     assert channel.messages == [
         (
             "\x01ACTION achieved #1 on [https://osu.cmyui.xyz/b/315 test map] "
@@ -503,17 +512,14 @@ async def test_announce_first_place_sends_message_with_previous_first_place() ->
     ]
 
 
-async def test_announce_first_place_omits_previous_holder_for_same_player() -> None:
+def test_announce_first_place_omits_previous_holder_for_same_player() -> None:
     score = _score()
     score.mods = Mods.NOMOD
-    scores = _FakeFirstPlaceScoresRepository(
-        {"id": 6, "name": "test-user"},
-    )
     channel = _FakeAnnounceChannel()
 
-    await score_submission.announce_first_place(
+    score_submission.announce_first_place(
         score,
-        scores=scores,
+        previous_first_place_score={"id": 6, "name": "test-user"},
         announce_channel=channel,
         domain="osu.cmyui.xyz",
     )
@@ -528,29 +534,21 @@ async def test_announce_first_place_omits_previous_holder_for_same_player() -> N
     ]
 
 
-async def test_announce_first_place_uses_score_for_vanilla_loved_score() -> None:
+def test_announce_first_place_uses_score_for_vanilla_loved_score() -> None:
     score = _score()
     score.bmap.status = RankedStatus.Loved
     score.mode = GameMode.VANILLA_OSU
     score.mods = Mods.NOMOD
     score.score = 1_234_567
-    scores = _FakeFirstPlaceScoresRepository()
     channel = _FakeAnnounceChannel()
 
-    await score_submission.announce_first_place(
+    score_submission.announce_first_place(
         score,
-        scores=scores,
+        previous_first_place_score=None,
         announce_channel=channel,
         domain="osu.cmyui.xyz",
     )
 
-    assert scores.calls == [
-        {
-            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
-            "mode": GameMode.VANILLA_OSU.value,
-            "scoring_metric": "score",
-        },
-    ]
     assert channel.messages == [
         (
             "\x01ACTION achieved #1 on [https://osu.cmyui.xyz/b/315 test map] "
@@ -570,7 +568,7 @@ async def test_announce_first_place_uses_score_for_vanilla_loved_score() -> None
         "no_leaderboard",
     ],
 )
-async def test_announce_first_place_skips_ineligible_scores(condition: str) -> None:
+def test_announce_first_place_skips_ineligible_scores(condition: str) -> None:
     score = _score()
     if condition == "non_best":
         score.status = SubmissionStatus.SUBMITTED
@@ -581,41 +579,28 @@ async def test_announce_first_place_skips_ineligible_scores(condition: str) -> N
     elif condition == "no_leaderboard":
         score.bmap.has_leaderboard = False
 
-    scores = _FakeFirstPlaceScoresRepository(
-        {"id": 9, "name": "old-user"},
-    )
     channel = _FakeAnnounceChannel()
 
-    await score_submission.announce_first_place(
+    score_submission.announce_first_place(
         score,
-        scores=scores,
+        previous_first_place_score={"id": 9, "name": "old-user"},
         announce_channel=channel,
         domain="osu.cmyui.xyz",
     )
 
-    assert scores.calls == []
     assert channel.messages == []
 
 
-async def test_announce_first_place_requires_announce_channel() -> None:
+def test_announce_first_place_requires_announce_channel() -> None:
     score = _score()
-    scores = _FakeFirstPlaceScoresRepository()
 
     with pytest.raises(AssertionError):
-        await score_submission.announce_first_place(
+        score_submission.announce_first_place(
             score,
-            scores=scores,
+            previous_first_place_score=None,
             announce_channel=None,
             domain="osu.cmyui.xyz",
         )
-
-    assert scores.calls == [
-        {
-            "map_md5": "1cf5b2c2edfafd055536d2cefcb89c0e",
-            "mode": GameMode.RELAX_OSU.value,
-            "scoring_metric": "pp",
-        },
-    ]
 
 
 class _FailingAchievements:
@@ -722,13 +707,13 @@ class _FakeScoresRepository:
     def __init__(
         self,
         best_scores: list[ScorePerformanceRow] | None = None,
-        current_first_place_score: CurrentFirstPlaceScore | None = None,
+        first_place_score: FirstPlaceScore | None = None,
     ) -> None:
         self.calls: list[str] = []
         self.previous_best_updates: list[_PreviousBestUpdate] = []
         self.created_scores: list[_CreatedScoreFields] = []
         self.best_scores = best_scores if best_scores is not None else []
-        self.current_first_place_score = current_first_place_score
+        self.first_place_score = first_place_score
         self.fetches: list[_ScorePerformanceFetch] = []
         self.first_place_score_fetches: list[_FirstPlaceScoreFetch] = []
 
@@ -765,14 +750,14 @@ class _FakeScoresRepository:
         self.fetches.append({"user_id": user_id, "mode": mode})
         return self.best_scores
 
-    async def fetch_current_first_place_score(
+    async def fetch_first_place_score(
         self,
         *,
         map_md5: str,
         mode: int,
         scoring_metric: ScoringMetric,
-    ) -> CurrentFirstPlaceScore | None:
-        self.calls.append("fetch_current_first_place_score")
+    ) -> FirstPlaceScore | None:
+        self.calls.append("fetch_first_place_score")
         self.first_place_score_fetches.append(
             {
                 "map_md5": map_md5,
@@ -780,7 +765,7 @@ class _FakeScoresRepository:
                 "scoring_metric": scoring_metric,
             },
         )
-        return self.current_first_place_score
+        return self.first_place_score
 
 
 class _FakeScorePerformanceRepository:
@@ -1179,7 +1164,7 @@ async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None
             {"pp": 100.0, "acc": 98.0},
             {"pp": 50.0, "acc": 95.0},
         ],
-        current_first_place_score={"id": 9, "name": "old-user"},
+        first_place_score={"id": 9, "name": "old-user"},
     )
     maps = _FakeMapsRepository()
     user_achievements = _FakeUserAchievements()
@@ -1197,7 +1182,7 @@ async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None
     assert database.calls == ["transaction", "transaction_enter", "transaction_exit"]
     assert database.transactions[0].exception_type is None
     assert scores.calls == [
-        "fetch_current_first_place_score",
+        "fetch_first_place_score",
         "mark_previous_best_scores_submitted",
         "create",
     ]

--- a/tests/unit/usecases/score_submission_test.py
+++ b/tests/unit/usecases/score_submission_test.py
@@ -5,6 +5,7 @@ from datetime import date
 from datetime import datetime
 from ipaddress import IPv4Address
 from types import SimpleNamespace
+from types import TracebackType
 from typing import TypedDict
 from typing import cast
 
@@ -684,11 +685,46 @@ class _FakeUserAchievements:
         return {"userid": user_id, "achid": achievement_id}
 
 
-class _FakeScoresRepository:
+class _FakeTransaction:
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+        self.exception_type: type[BaseException] | None = None
+
+    async def __aenter__(self) -> None:
+        self.calls.append("transaction_enter")
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.exception_type = exc_type
+        self.calls.append("transaction_exit")
+
+
+class _FakeDatabaseTransactions:
     def __init__(self) -> None:
+        self.calls: list[str] = []
+        self.transactions: list[_FakeTransaction] = []
+
+    def transaction(self) -> _FakeTransaction:
+        self.calls.append("transaction")
+        transaction = _FakeTransaction(self.calls)
+        self.transactions.append(transaction)
+        return transaction
+
+
+class _FakeScoresRepository:
+    def __init__(
+        self,
+        best_scores: list[ScorePerformanceRow] | None = None,
+    ) -> None:
         self.calls: list[str] = []
         self.previous_best_updates: list[_PreviousBestUpdate] = []
         self.created_scores: list[_CreatedScoreFields] = []
+        self.best_scores = best_scores if best_scores is not None else []
+        self.fetches: list[_ScorePerformanceFetch] = []
 
     async def create(
         self,
@@ -713,6 +749,24 @@ class _FakeScoresRepository:
                 "mode": mode,
             },
         )
+
+    async def fetch_weighted_best_performances(
+        self,
+        *,
+        user_id: int,
+        mode: int,
+    ) -> list[ScorePerformanceRow]:
+        self.fetches.append({"user_id": user_id, "mode": mode})
+        return self.best_scores
+
+    async def fetch_previous_first_place(
+        self,
+        *,
+        map_md5: str,
+        mode: int,
+        scoring_metric: ScoringMetric,
+    ) -> PreviousFirstPlace | None:
+        raise AssertionError("previous first place should not be fetched")
 
 
 class _FakeScorePerformanceRepository:
@@ -781,6 +835,15 @@ class _FakeMapsRepository:
                 },
             },
         )
+
+
+class _FailingMapsRepository:
+    async def partial_update(
+        self,
+        id: int,
+        **updates: object,
+    ) -> None:
+        raise RuntimeError("map update failed")
 
 
 class _FakeUserStatsPublisher:
@@ -929,7 +992,6 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
         stats=stats_repo,
         scores=scores_repo,
         maps=maps_repo,
-        publish_user_stats=publish_user_stats,
     )
 
     assert result.previous_stats.plays == 0
@@ -941,8 +1003,10 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
     assert result.current_stats.rscore == 27_810
     assert result.current_stats.acc == pytest.approx(96.5384615385)
     assert result.current_stats.pp == 148
-    assert result.current_stats.rank == 7
-    assert player.updated_rank_modes == [GameMode.RELAX_OSU]
+    assert result.current_stats.rank == 0
+    assert result.should_update_rank
+    assert result.should_publish_user_stats
+    assert player.updated_rank_modes == []
     assert scores_repo.fetches == [
         {
             "user_id": 6,
@@ -965,7 +1029,7 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
             },
         },
     ]
-    assert publish_user_stats.published_players == [player]
+    assert publish_user_stats.published_players == []
     assert score.bmap.plays == 2
     assert score.bmap.passes == 2
     assert maps_repo.partial_updates == [
@@ -977,6 +1041,25 @@ async def test_persist_score_submission_stats_updates_ranked_best_score_side_eff
             },
         },
     ]
+    assert player.recent_scores == {}
+
+    persistence_result = score_submission.ScoreSubmissionPersistenceResult(
+        score_id=123,
+        previous_stats=result.previous_stats,
+        current_stats=result.current_stats,
+        unlocked_achievements=[],
+        should_update_rank=result.should_update_rank,
+        should_publish_user_stats=result.should_publish_user_stats,
+    )
+    await score_submission.apply_score_submission_side_effects(
+        score,
+        persistence_result,
+        publish_user_stats=publish_user_stats,
+    )
+
+    assert result.current_stats.rank == 7
+    assert player.updated_rank_modes == [GameMode.RELAX_OSU]
+    assert publish_user_stats.published_players == [player]
     assert player.recent_scores[GameMode.RELAX_OSU] is score
 
 
@@ -1005,7 +1088,6 @@ async def test_persist_score_submission_stats_updates_failed_score_without_weigh
         stats=stats_repo,
         scores=_FailingScorePerformanceRepository(),
         maps=maps_repo,
-        publish_user_stats=publish_user_stats,
     )
 
     assert result.previous_stats.plays == 2
@@ -1013,6 +1095,8 @@ async def test_persist_score_submission_stats_updates_failed_score_without_weigh
     assert result.current_stats.playtime == 18
     assert result.current_stats.tscore == 26_820
     assert result.current_stats.total_hits == 109
+    assert not result.should_update_rank
+    assert result.should_publish_user_stats
     assert player.updated_rank_modes == []
     assert stats_repo.partial_updates == [
         {
@@ -1026,7 +1110,8 @@ async def test_persist_score_submission_stats_updates_failed_score_without_weigh
             },
         },
     ]
-    assert player.recent_scores[GameMode.RELAX_OSU] is score
+    assert publish_user_stats.published_players == []
+    assert player.recent_scores == {}
 
 
 async def test_persist_score_submission_stats_skips_public_side_effects_for_restricted_player() -> (
@@ -1047,20 +1132,123 @@ async def test_persist_score_submission_stats_skips_public_side_effects_for_rest
     maps_repo = _FakeMapsRepository()
     publish_user_stats = _FakeUserStatsPublisher()
 
-    await score_submission.persist_score_submission_stats(
+    result = await score_submission.persist_score_submission_stats(
         score,
         stats=stats_repo,
         scores=_FakeScorePerformanceRepository(),
         maps=maps_repo,
-        publish_user_stats=publish_user_stats,
     )
 
     assert stats_repo.partial_updates != []
+    assert not result.should_publish_user_stats
     assert publish_user_stats.published_players == []
     assert score.bmap.plays == 1
     assert score.bmap.passes == 1
     assert maps_repo.partial_updates == []
-    assert player.recent_scores[GameMode.RELAX_OSU] is score
+    assert player.recent_scores == {}
+
+
+async def test_persist_score_submission_wraps_db_writes_in_transaction() -> None:
+    score = _score()
+    score.client_checksum = "client-checksum"
+    stats = _mode_data(
+        rscore=1_000,
+        max_combo=40,
+        grades=_grade_counts(),
+    )
+    player = _FakePlayer(stats=stats)
+    score.player = player
+    database = _FakeDatabaseTransactions()
+    scores = _FakeScoresRepository(
+        best_scores=[
+            {"pp": 100.0, "acc": 98.0},
+            {"pp": 50.0, "acc": 95.0},
+        ],
+    )
+    maps = _FakeMapsRepository()
+    user_achievements = _FakeUserAchievements()
+
+    result = await score_submission.persist_score_submission(
+        score,
+        database=database,
+        scores=scores,
+        stats=_FakeStatsRepository(),
+        maps=maps,
+        achievements=_FakeAchievements(),
+        user_achievements=user_achievements,
+    )
+
+    assert database.calls == ["transaction", "transaction_enter", "transaction_exit"]
+    assert database.transactions[0].exception_type is None
+    assert scores.calls == ["mark_previous_best_scores_submitted", "create"]
+    assert maps.partial_updates == [
+        {
+            "id": 315,
+            "updates": {
+                "plays": 2,
+                "passes": 2,
+            },
+        },
+    ]
+    assert user_achievements.created_achievement_ids == [1]
+    assert result.score_id == 123
+    assert [achievement["id"] for achievement in result.unlocked_achievements] == [1]
+    assert result.should_update_rank
+    assert result.should_publish_user_stats
+    assert player.updated_rank_modes == []
+    assert player.recent_scores == {}
+
+
+async def test_persist_score_submission_restores_memory_state_on_failure() -> None:
+    score = _score()
+    score.id = None
+    score.client_checksum = "client-checksum"
+    score.bmap.plays = 10
+    score.bmap.passes = 9
+    previous_recent_score = _score()
+    stats = _mode_data(
+        plays=2,
+        playtime=5,
+        tscore=10,
+        total_hits=7,
+        rscore=1_000,
+        max_combo=40,
+        grades=_grade_counts(a=2),
+    )
+    player = _FakePlayer(stats=stats)
+    player.recent_scores[GameMode.RELAX_OSU] = previous_recent_score
+    score.player = player
+    database = _FakeDatabaseTransactions()
+
+    with pytest.raises(RuntimeError, match="map update failed"):
+        await score_submission.persist_score_submission(
+            score,
+            database=database,
+            scores=_FakeScoresRepository(
+                best_scores=[
+                    {"pp": 100.0, "acc": 98.0},
+                    {"pp": 50.0, "acc": 95.0},
+                ],
+            ),
+            stats=_FakeStatsRepository(),
+            maps=_FailingMapsRepository(),
+            achievements=_FakeAchievements(),
+            user_achievements=_FakeUserAchievements(),
+        )
+
+    assert database.calls == ["transaction", "transaction_enter", "transaction_exit"]
+    assert database.transactions[0].exception_type is RuntimeError
+    assert score.id is None
+    assert score.bmap.plays == 10
+    assert score.bmap.passes == 9
+    assert player.stats[GameMode.RELAX_OSU].plays == 2
+    assert player.stats[GameMode.RELAX_OSU].playtime == 5
+    assert player.stats[GameMode.RELAX_OSU].tscore == 10
+    assert player.stats[GameMode.RELAX_OSU].total_hits == 7
+    assert player.stats[GameMode.RELAX_OSU].rscore == 1_000
+    assert player.stats[GameMode.RELAX_OSU].max_combo == 40
+    assert player.stats[GameMode.RELAX_OSU].grades[Grade.A] == 2
+    assert player.recent_scores[GameMode.RELAX_OSU] is previous_recent_score
 
 
 def test_parse_unique_id_hashes_md5s_submission_unique_ids() -> None:


### PR DESCRIPTION
## Summary
- wrap score submission DB persistence in a service-layer transaction
- move rank publish, user stats enqueue, recent-score update, replay disk write, and first-place announcement sending to post-commit side effects
- split replay validation from replay file writing so missing-replay restrictions still happen before stats/map public updates
- unlock achievements inside the score submission transaction and pass the unlocked achievements into response building
- restore in-memory score/stat/beatmap/recent-score state if transactional persistence fails

## Notes
- External side effects remain outside the DB transaction.
- First-place announcements are prepared before the transaction, while the previous #1 can still be read, then sent after commit.

## Verification
- `make lint`
- `make utest`
- `make type-check`
- `make test`